### PR TITLE
Feature/#30 api modularization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ dist-ssr
 
 
 .eslintcache
+
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "react-hook-form": "^7.41.5",
         "react-icons": "^4.7.1",
         "react-router-dom": "^6.6.1",
+        "react-toastify": "^9.1.1",
         "recoil": "^0.7.6",
         "styled-components": "^5.3.6",
         "styled-reset": "^4.4.4"
@@ -1760,6 +1761,14 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -4021,6 +4030,18 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.1.1.tgz",
+      "integrity": "sha512-pkFCla1z3ve045qvjEmn2xOJOy4ZciwRXm1oMPULVkELi5aJdHCN/FHnuqXq8IwGDLB7PPk2/J6uP9D8ejuiRw==",
+      "dependencies": {
+        "clsx": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/recoil": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@tanstack/react-query": "^4.20.4",
         "@tanstack/react-query-devtools": "^4.20.4",
         "axios": "^1.2.1",
+        "jwt-decode": "^3.1.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.41.5",
@@ -3400,6 +3401,11 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "node_modules/language-subtag-registry": {
       "version": "0.3.22",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@tanstack/react-query": "^4.20.4",
     "@tanstack/react-query-devtools": "^4.20.4",
     "axios": "^1.2.1",
+    "jwt-decode": "^3.1.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.41.5",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-hook-form": "^7.41.5",
     "react-icons": "^4.7.1",
     "react-router-dom": "^6.6.1",
+    "react-toastify": "^9.1.1",
     "recoil": "^0.7.6",
     "styled-components": "^5.3.6",
     "styled-reset": "^4.4.4"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,9 +2,23 @@ import { Layout } from '@components/layout';
 import { ThemeProvider } from 'styled-components';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
-import { GlobalStyle, theme } from '@styles';
+import { ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 
-const queryClient = new QueryClient();
+import { GlobalStyle, theme } from '@styles';
+import { queryErrorHandler } from 'utils/queryErrorHandler';
+
+const defaultQueryClientOptions = {
+  queries: {
+    onError: queryErrorHandler,
+  },
+  mutations: {
+    onError: queryErrorHandler,
+  },
+};
+const queryClient = new QueryClient({
+  defaultOptions: defaultQueryClientOptions,
+});
 
 function App() {
   return (
@@ -14,6 +28,7 @@ function App() {
         <Layout />
       </ThemeProvider>
       <ReactQueryDevtools initialIsOpen={false} />
+      <ToastContainer position="top-center" pauseOnFocusLoss theme="light" />
     </QueryClientProvider>
   );
 }

--- a/src/apis/authService.ts
+++ b/src/apis/authService.ts
@@ -1,0 +1,37 @@
+import type { SignInInput, SignUpInput } from '@projects/types/basic';
+import type { HttpClientImpl } from './httpClient';
+import type { TokenRepositoryImpl } from './tokenRepository';
+
+export class AuthService {
+  constructor(
+    private httpClient: HttpClientImpl,
+    private tokenRepository: TokenRepositoryImpl
+  ) {
+    this.httpClient = httpClient;
+    this.tokenRepository = tokenRepository;
+  }
+
+  signUp = async (userData: SignUpInput) => {
+    const response = await this.httpClient.post<string, SignUpInput>(
+      '/join',
+      userData
+    );
+    return response.data;
+  };
+
+  signIn = async (userData: SignInInput) => {
+    const response = await this.httpClient.post<string, SignInInput>(
+      '/login',
+      userData
+    );
+    const token = response.headers.authorization;
+    if (token) {
+      this.tokenRepository.saveToken(token.split(' ')[1]); // Bearer를 삭제한 토큰값만 저장
+    }
+    return '로그인에 성공했습니다';
+  };
+
+  signOut = () => {
+    this.tokenRepository.removeToken();
+  };
+}

--- a/src/apis/externalService.ts
+++ b/src/apis/externalService.ts
@@ -1,0 +1,27 @@
+import type { SearchBookInfo, RecommendSort } from '@projects/types/basic';
+import type { HttpClientImpl } from './httpClient';
+
+interface ExternalService {
+  searchBooks: (keyword: string) => Promise<SearchBookInfo[]>;
+  getRecommendedBooksList: (sort: RecommendSort) => Promise<SearchBookInfo[]>;
+}
+
+export class ExternalServiceImpl implements ExternalService {
+  constructor(private httpClient: HttpClientImpl) {
+    this.httpClient = httpClient;
+  }
+
+  searchBooks = async (keyword: string) => {
+    const { data } = await this.httpClient.get<SearchBookInfo[]>(
+      `/ext-lib/${keyword}`
+    );
+    return data;
+  };
+
+  getRecommendedBooksList = async (sort: RecommendSort) => {
+    const { data } = await this.httpClient.get<SearchBookInfo[]>(
+      `/ext-lib/${sort}`
+    );
+    return data;
+  };
+}

--- a/src/apis/httpClient.ts
+++ b/src/apis/httpClient.ts
@@ -1,0 +1,49 @@
+import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
+
+interface HttpClient {
+  get: <T>(
+    endPoint: string,
+    config?: AxiosRequestConfig
+  ) => Promise<AxiosResponse<T>>;
+  post: <T, D>(
+    endPoint: string,
+    data: D,
+    config?: AxiosRequestConfig
+  ) => Promise<AxiosResponse<T>>;
+  patch: <T, D>(
+    endPoint: string,
+    data: D,
+    config?: AxiosRequestConfig
+  ) => Promise<AxiosResponse<T>>;
+  delete: <T>(
+    endPoint: string,
+    config?: AxiosRequestConfig
+  ) => Promise<AxiosResponse<T>>;
+}
+
+export class HttpClientImpl implements HttpClient {
+  protected instance: AxiosInstance;
+
+  constructor(baseURL: string) {
+    this.instance = axios.create({
+      baseURL,
+      withCredentials: true,
+    });
+  }
+
+  get = async <T>(endPoint: string, config?: AxiosRequestConfig) => {
+    return this.instance.get<T>(endPoint, config);
+  };
+
+  post = <T, D>(endPoint: string, data: D, config?: AxiosRequestConfig<D>) => {
+    return this.instance.post<T, AxiosResponse<T>, D>(endPoint, data, config);
+  };
+
+  patch = <T, D>(endPoint: string, data: D, config?: AxiosRequestConfig<D>) => {
+    return this.instance.put<T, AxiosResponse<T>, D>(endPoint, data, config);
+  };
+
+  delete = <T>(endPoint: string, config?: AxiosRequestConfig) => {
+    return this.instance.delete<T, AxiosResponse<T>>(endPoint, config);
+  };
+}

--- a/src/apis/httpClient.ts
+++ b/src/apis/httpClient.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 
-interface HttpClient {
+export interface HttpClient {
   get: <T>(
     endPoint: string,
     config?: AxiosRequestConfig

--- a/src/apis/httpClientAuth.ts
+++ b/src/apis/httpClientAuth.ts
@@ -1,8 +1,6 @@
 import type { AxiosRequestConfig, AxiosError } from 'axios';
-import { useNavigate } from 'react-router-dom';
 import { HttpClientImpl, HttpClient } from './httpClient';
 import type { TokenRepositoryImpl } from './tokenRepository';
-import { PAGE_URL } from '../constants/path';
 
 const addAuthHeader = (
   config: AxiosRequestConfig,
@@ -20,9 +18,6 @@ const handleUnauthorizedError = (
 ) => {
   if (error.response?.status === 403) {
     tokenRepository.removeToken();
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const navigate = useNavigate();
-    navigate(PAGE_URL.SIGN_IN);
   }
   throw error;
 };

--- a/src/apis/httpClientAuth.ts
+++ b/src/apis/httpClientAuth.ts
@@ -1,0 +1,44 @@
+import type { AxiosRequestConfig, AxiosError } from 'axios';
+import { useNavigate } from 'react-router-dom';
+import { HttpClientImpl, HttpClient } from './httpClient';
+import type { TokenRepositoryImpl } from './tokenRepository';
+import { PAGE_URL } from '../constants/path';
+
+const addAuthHeader = (
+  config: AxiosRequestConfig,
+  tokenRepository: TokenRepositoryImpl
+) => {
+  const newConfig: AxiosRequestConfig = { ...config };
+  if (!newConfig.headers) newConfig.headers = {};
+  newConfig.headers.Authorization = `Bearer ${tokenRepository.getToken()}`;
+  return newConfig;
+};
+
+const handleUnauthorizedError = (
+  error: AxiosError,
+  tokenRepository: TokenRepositoryImpl
+) => {
+  if (error.response?.status === 403) {
+    tokenRepository.removeToken();
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const navigate = useNavigate();
+    navigate(PAGE_URL.SIGN_IN);
+  }
+  throw error;
+};
+
+export class HttpClientAuthImpl extends HttpClientImpl implements HttpClient {
+  constructor(baseURL: string, private tokenRepository: TokenRepositoryImpl) {
+    super(baseURL);
+    this.tokenRepository = tokenRepository;
+    this.instance.interceptors.request.use((config) => {
+      return addAuthHeader(config, this.tokenRepository);
+    });
+    this.instance.interceptors.response.use(
+      (response) => response,
+      (error: AxiosError) => {
+        return handleUnauthorizedError(error, tokenRepository);
+      }
+    );
+  }
+}

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,17 +1,25 @@
 import { UserInfo } from '@projects/types/basic';
 import axios from 'axios';
+import { AuthService } from './authService';
+import { HttpClientImpl } from './httpClient';
+import { TokenRepositoryImpl } from './tokenRepository';
 
 const BASE_URL = import.meta.env.VITE_APP_BASE_URL;
 
+export const httpClient = new HttpClientImpl(BASE_URL);
+export const tokenRepository = new TokenRepositoryImpl();
+
+export const authService = new AuthService(httpClient, tokenRepository);
+
 // 책 검색 (외부API)
 export const getBookInfo = async (keyword: string) => {
-  const { data } = await axios.get(`${BASE_URL}ext-lib/${keyword}`);
+  const { data } = await axios.get(`${BASE_URL}/ext-lib/${keyword}`);
   return data;
 };
 
 // 베스트셀러 조회 | 주목할만한 신간 리스트 조회 외부(API)
 export const getRecommendedBooksList = async (sort: string) => {
-  const { data } = await axios.get(`${BASE_URL}ext-lib/${sort}`);
+  const { data } = await axios.get(`${BASE_URL}/ext-lib/${sort}`);
   return data;
 };
 
@@ -19,7 +27,7 @@ export const getRecommendedBooksList = async (sort: string) => {
 export const postSignIn = async (
   SignInuserInfoData: Pick<UserInfo, 'email' | 'password'>
 ) => {
-  const response = await axios.post(`${BASE_URL}login`, SignInuserInfoData, {
+  const response = await axios.post(`${BASE_URL}/login`, SignInuserInfoData, {
     withCredentials: true,
   });
   return response.headers.authorization;
@@ -29,7 +37,7 @@ export const postSignIn = async (
 export const postSignUp = async (
   SignUpuserInfoData: Omit<UserInfo, 'password_confirm'>
 ) => {
-  const response = await axios.post(`${BASE_URL}join`, SignUpuserInfoData, {
+  const response = await axios.post(`${BASE_URL}/join`, SignUpuserInfoData, {
     withCredentials: true,
   });
   return response;

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,15 +1,17 @@
 import { UserInfo } from '@projects/types/basic';
 import axios from 'axios';
 
+const BASE_URL = import.meta.env.VITE_APP_BASE_URL;
+
 // 책 검색 (외부API)
 export const getBookInfo = async (keyword: string) => {
-  const { data } = await axios.get(`https://seollem.link/ext-lib/${keyword}`);
+  const { data } = await axios.get(`${BASE_URL}ext-lib/${keyword}`);
   return data;
 };
 
 // 베스트셀러 조회 | 주목할만한 신간 리스트 조회 외부(API)
 export const getRecommendedBooksList = async (sort: string) => {
-  const { data } = await axios.get(`https://seollem.link/ext-lib/${sort}`);
+  const { data } = await axios.get(`${BASE_URL}ext-lib/${sort}`);
   return data;
 };
 
@@ -17,13 +19,9 @@ export const getRecommendedBooksList = async (sort: string) => {
 export const postSignIn = async (
   SignInuserInfoData: Pick<UserInfo, 'email' | 'password'>
 ) => {
-  const response = await axios.post(
-    `https://seollem.link/login`,
-    SignInuserInfoData,
-    {
-      withCredentials: true,
-    }
-  );
+  const response = await axios.post(`${BASE_URL}login`, SignInuserInfoData, {
+    withCredentials: true,
+  });
   return response.headers.authorization;
 };
 
@@ -31,12 +29,8 @@ export const postSignIn = async (
 export const postSignUp = async (
   SignUpuserInfoData: Omit<UserInfo, 'password_confirm'>
 ) => {
-  const response = await axios.post(
-    `https://seollem.link/join`,
-    SignUpuserInfoData,
-    {
-      withCredentials: true,
-    }
-  );
+  const response = await axios.post(`${BASE_URL}join`, SignUpuserInfoData, {
+    withCredentials: true,
+  });
   return response;
 };

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -3,14 +3,15 @@ import axios from 'axios';
 import { AuthService } from './authService';
 import { HttpClientImpl } from './httpClient';
 import { TokenRepositoryImpl } from './tokenRepository';
+import { ExternalServiceImpl } from './externalService';
 
 const BASE_URL = import.meta.env.VITE_APP_BASE_URL;
 
-export const httpClient = new HttpClientImpl(BASE_URL);
 export const tokenRepository = new TokenRepositoryImpl();
+export const httpClient = new HttpClientImpl(BASE_URL);
 
 export const authService = new AuthService(httpClient, tokenRepository);
-
+export const externalService = new ExternalServiceImpl(httpClient);
 // 책 검색 (외부API)
 export const getBookInfo = async (keyword: string) => {
   const { data } = await axios.get(`${BASE_URL}/ext-lib/${keyword}`);

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -4,14 +4,22 @@ import { AuthService } from './authService';
 import { HttpClientImpl } from './httpClient';
 import { TokenRepositoryImpl } from './tokenRepository';
 import { ExternalServiceImpl } from './externalService';
+import { ProfileServiceImpl } from './profileService';
+import { HttpClientAuthImpl } from './httpClientAuth';
 
 const BASE_URL = import.meta.env.VITE_APP_BASE_URL;
 
 export const tokenRepository = new TokenRepositoryImpl();
 export const httpClient = new HttpClientImpl(BASE_URL);
+export const httpClientAuth = new HttpClientAuthImpl(BASE_URL, tokenRepository);
 
 export const authService = new AuthService(httpClient, tokenRepository);
 export const externalService = new ExternalServiceImpl(httpClient);
+export const profileService = new ProfileServiceImpl(
+  httpClientAuth,
+  tokenRepository
+);
+
 // 책 검색 (외부API)
 export const getBookInfo = async (keyword: string) => {
   const { data } = await axios.get(`${BASE_URL}/ext-lib/${keyword}`);

--- a/src/apis/profileService.ts
+++ b/src/apis/profileService.ts
@@ -1,0 +1,61 @@
+import type { Profile } from '../types/basic';
+import type { HttpClientAuthImpl } from './httpClientAuth';
+import type { TokenRepositoryImpl } from './tokenRepository';
+
+type EditUserParams = {
+  name?: string;
+  password?: string;
+};
+
+type EditUserResponse = {
+  email: string;
+  name: string;
+  updatedAt: Date;
+};
+
+interface ProfileService {
+  getProfile: () => Promise<Profile>;
+  editProfileName: (name: string) => Promise<EditUserResponse>;
+  editProfilePassword: (password: string) => Promise<EditUserResponse>;
+  deleteProfile: () => Promise<string>;
+}
+
+export class ProfileServiceImpl implements ProfileService {
+  private endPoint = '/members/me';
+
+  constructor(
+    private httpClient: HttpClientAuthImpl,
+    private tokenRepository: TokenRepositoryImpl
+  ) {}
+
+  getProfile = async () => {
+    const { data } = await this.httpClient.get<Profile>(this.endPoint);
+    return data;
+  };
+
+  editProfileName = async (name: string) => {
+    const { data } = await this.httpClient.patch<
+      EditUserResponse,
+      EditUserParams
+    >(this.endPoint, { name });
+
+    return data;
+  };
+
+  editProfilePassword = async (password: string) => {
+    const { data } = await this.httpClient.patch<
+      EditUserResponse,
+      EditUserParams
+    >(this.endPoint, { password });
+
+    return data;
+  };
+
+  deleteProfile = async () => {
+    const response = await this.httpClient.delete(this.endPoint);
+    if (response.status === 204) {
+      this.tokenRepository.removeToken();
+    }
+    return '회원 탈퇴되었습니다';
+  };
+}

--- a/src/apis/tokenRepository.ts
+++ b/src/apis/tokenRepository.ts
@@ -1,0 +1,46 @@
+import jwtDecode from 'jwt-decode';
+
+type JwtPayload = {
+  sub: string;
+  id: number;
+  exp: number;
+  email: string;
+};
+
+interface TokenRepository {
+  saveToken: (token: string) => void;
+  getToken: () => string | null;
+  removeToken: () => void;
+  isValidToken: () => boolean;
+}
+
+export class TokenRepositoryImpl implements TokenRepository {
+  private TOKEN_KEY = 'ACCESS_TOKEN';
+
+  saveToken = (token: string) => {
+    localStorage.setItem(this.TOKEN_KEY, token);
+  };
+
+  getToken = () => {
+    return localStorage.getItem(this.TOKEN_KEY);
+  };
+
+  removeToken = () => {
+    localStorage.removeItem(this.TOKEN_KEY);
+  };
+
+  isValidToken = () => {
+    const token = this.getToken();
+
+    if (token) {
+      const { exp: expireTime } = jwtDecode<JwtPayload>(token);
+      const currentTime = Math.floor(Date.now() / 1000);
+
+      return currentTime < expireTime;
+    }
+
+    return false;
+  };
+}
+
+// TODO: 서버에서 refresh 토큰 응답이 추가되면 수정 필요

--- a/src/apis/tokenRepository.ts
+++ b/src/apis/tokenRepository.ts
@@ -1,17 +1,7 @@
-import jwtDecode from 'jwt-decode';
-
-type JwtPayload = {
-  sub: string;
-  id: number;
-  exp: number;
-  email: string;
-};
-
 interface TokenRepository {
   saveToken: (token: string) => void;
   getToken: () => string | null;
   removeToken: () => void;
-  isValidToken: () => boolean;
 }
 
 export class TokenRepositoryImpl implements TokenRepository {
@@ -27,19 +17,6 @@ export class TokenRepositoryImpl implements TokenRepository {
 
   removeToken = () => {
     localStorage.removeItem(this.TOKEN_KEY);
-  };
-
-  isValidToken = () => {
-    const token = this.getToken();
-
-    if (token) {
-      const { exp: expireTime } = jwtDecode<JwtPayload>(token);
-      const currentTime = Math.floor(Date.now() / 1000);
-
-      return currentTime < expireTime;
-    }
-
-    return false;
   };
 }
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,32 +1,3 @@
-// TODO
-// 새로 추가되는 페이지 컴포넌트명 - url 정의하기
-export const PAGE_URL = {
-  ROOT: '/',
-  NOT_FOUND: '*',
-  SIGN_IN: '/auth/signin',
-  SIGN_UP: '/auth/signup',
-  MYSTAT: '/mystat',
-  MYPAGE: '/mypage',
-  SEARCHBOOK: '/book/search',
-  POSTBOOK: '/book/register/:id',
-  DETAILBOOKINFO: '/book/detail/:id',
-  RECOMMENDEDBOOKS: '/book/recommended',
-};
-export const EMAIL_REGEX =
-  /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$/;
-
-export const PASSWORD_REGEX =
-  /^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*])[A-Za-z0-9!@#$%^&*]{6,}$/;
-
-export const RECOMMENDED_SORT = [
-  {
-    id: 0,
-    name: '베스트셀러',
-    value: 'best-seller',
-  },
-  {
-    id: 1,
-    name: '주목할만한 신간 리스트',
-    value: 'item-new-special',
-  },
-];
+export * from './path';
+export * from './regex';
+export * from './recommend';

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -1,0 +1,12 @@
+export const PAGE_URL = {
+  ROOT: '/',
+  NOT_FOUND: '*',
+  SIGN_IN: '/auth/signin',
+  SIGN_UP: '/auth/signup',
+  MYSTAT: '/mystat',
+  MYPAGE: '/mypage',
+  SEARCHBOOK: '/book/search',
+  POSTBOOK: '/book/register/:id',
+  DETAILBOOKINFO: '/book/detail/:id',
+  RECOMMENDEDBOOKS: '/book/recommended',
+};

--- a/src/constants/recommend.ts
+++ b/src/constants/recommend.ts
@@ -1,0 +1,12 @@
+export const RECOMMENDED_SORT = [
+  {
+    id: 0,
+    name: '베스트셀러',
+    value: 'best-seller',
+  },
+  {
+    id: 1,
+    name: '주목할만한 신간 리스트',
+    value: 'item-new-special',
+  },
+];

--- a/src/constants/regex.ts
+++ b/src/constants/regex.ts
@@ -1,0 +1,5 @@
+export const EMAIL_REGEX =
+  /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$/;
+
+export const PASSWORD_REGEX =
+  /^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*])[A-Za-z0-9!@#$%^&*]{6,}$/;

--- a/src/types/basic.ts
+++ b/src/types/basic.ts
@@ -22,7 +22,7 @@ export interface UserInfo {
   password: string;
   password_confirm: string;
 }
-
+export type Profile = Pick<UserInfo, 'email' | 'name'>;
 export type SignInInput = Pick<UserInfo, 'email' | 'password'>;
 export type SignUpInput = Omit<UserInfo, 'password_confirm'>;
 

--- a/src/types/basic.ts
+++ b/src/types/basic.ts
@@ -22,6 +22,10 @@ export interface UserInfo {
   password: string;
   password_confirm: string;
 }
+
+export type SignInInput = Pick<UserInfo, 'email' | 'password'>;
+export type SignUpInput = Omit<UserInfo, 'password_confirm'>;
+
 export interface SignInputProps {
   label: SignInputLabel;
   register: UseFormRegister<UserInfo>;

--- a/src/types/basic.ts
+++ b/src/types/basic.ts
@@ -26,6 +26,8 @@ export interface UserInfo {
 export type SignInInput = Pick<UserInfo, 'email' | 'password'>;
 export type SignUpInput = Omit<UserInfo, 'password_confirm'>;
 
+export type RecommendSort = 'best-seller' | 'item-new-special';
+
 export interface SignInputProps {
   label: SignInputLabel;
   register: UseFormRegister<UserInfo>;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,1 @@
-export {};
+export * from './isValidToken';

--- a/src/utils/isValidToken.ts
+++ b/src/utils/isValidToken.ts
@@ -1,0 +1,15 @@
+import jwtDecode from 'jwt-decode';
+
+type JwtPayload = {
+  sub: string;
+  id: number;
+  exp: number;
+  email: string;
+};
+
+export const isValidToken = (token: string) => {
+  const { exp: expireTime } = jwtDecode<JwtPayload>(token);
+  const currentTime = Math.floor(Date.now() / 1000);
+
+  return currentTime < expireTime;
+};

--- a/src/utils/queryErrorHandler.ts
+++ b/src/utils/queryErrorHandler.ts
@@ -1,0 +1,10 @@
+import { AxiosError } from 'axios';
+import { toast } from 'react-toastify';
+
+export const queryErrorHandler = (error: unknown) => {
+  let message = 'Error connecting to server';
+  if (error instanceof AxiosError && error.response) {
+    message = error.response.data.message || '잠시 후 다시 시도해보세요';
+  }
+  toast.error(message);
+};

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_APP_BASE_URL: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## 🔗 ISSUE NUMBER
<!-- closed #[issue-number]로 작성하면 이슈가 닫히고, 링크도 연결할 수 있어요 -->

- closed #30 

## 🙌 구현 사항
- 서버 url 환경변수 설정 
- TokenRepository 
- HttpClient
- api service class(auth, external, profile)
- queryErrorHandler, defaultOptions 설정

## 📝 구현 설명
이전 프로젝트에서 개선하고 싶었 점은 아래와 같습니다. 
✅  api 설정에서 공통적인 부분(base url, header값 설정)을 모든 요청마다 작성하고 있음
✅  ui상에 사용자가 이해하기 어려운 서버의 응답이 그대로 노출되는 부분(403~~~) → 에러 메시지 커스텀화 
✅  api 응답 값에 대한 type 지정
✅  토큰에 대한 만료 처리

### TokenRepository 
token을 로컬스토리지에 저장, 삭제하고 가져오는 역할. key값을 함께 저장하기 위해서 class 형태로 구현했습니다(da0e913)

### HttpClient, HttpClinetAuth
HttpClient - base url을 입력받아서 axios인스턴스를 생성, axios 각 요청에 대한 요청과 응답 데이터 타입 지정 (a4f01ca)
```typescript
  get = async <T>(endPoint: string, config?: AxiosRequestConfig) => {
    return this.instance.get<T>(endPoint, config);
  };

  post = <T, D>(endPoint: string, data: D, config?: AxiosRequestConfig<D>) => {
    return this.instance.post<T, AxiosResponse<T>, D>(endPoint, data, config);
  };

  patch = <T, D>(endPoint: string, data: D, config?: AxiosRequestConfig<D>) => {
    return this.instance.put<T, AxiosResponse<T>, D>(endPoint, data, config);
  };

  delete = <T>(endPoint: string, config?: AxiosRequestConfig) => {
    return this.instance.delete<T, AxiosResponse<T>>(endPoint, config);
  };
```
HttpClinetAuth - auth header가 필요한 요청의 경우에 사용하는 인스턴스입니다. axios interceptor를 이용해서 요청에는 auth header를 설정하고, 403(토큰이 만료되었거나 auth header설정이 잘못된 경우)에러에 대한 처리(현재는 로컬스토리지에 저장된 토큰값 삭제하고 있는데, 백엔드에서 리프레시 토큰을 구현한 이후에는 여기에 refresh 토큰으로 accessToken을 재발급하는 api를 연결시킬 예정입니다.) (dd81ed5)
 ```typescript
export class HttpClientAuthImpl extends HttpClientImpl implements HttpClient {
  constructor(baseURL: string, private tokenRepository: TokenRepositoryImpl) {
    super(baseURL);
    this.tokenRepository = tokenRepository;
    this.instance.interceptors.request.use((config) => {
      return addAuthHeader(config, this.tokenRepository);
    });
    this.instance.interceptors.response.use(
      (response) => response,
      (error: AxiosError) => {
        return handleUnauthorizedError(error, tokenRepository);
      }
    );
  }
}
```
### Service 
endpoint별로 httpClient를 주입받습니다. 각 api service의 구체적인 응답값 타입을 지정합니다(external, auth, profile), 해당 요청의 응답 타입이 지정되었기 때문에 query나 mutation을 사용할때 추가적으로 타입을 지정하지 않아도 됩니다. 52002b1, 3091427, f629f41

### tanstack query 공통 에러 핸들링 
에러 처리는 가장 고민했던 부분인데, 현재 구현은 httpClientAuth에서는 인증 토큰과 관련된 403 error를 처리하고 그 외의 에러는 그대로 던져주게 됩니다. tanstack query의 query, mutation 훅을 사용할 경우에 서버의 에러 응답을 toast message로 화면에 표시합니다. 에러응답 메시지를 react-toastify를 이용해서 띄워주는 errorHandler 함수와 queryClient의 defaultOptions을 통해서 구현했습니다. 현재 서버 응답에 에러 데이터가 담겨오는 경우에는 toastify로 적절한 에러메시지 띄울 수 있는데, 서버에서 에러 데이터가 담겨오지 않은 경우에 대해서는 errorHandler에 설정된 메시지만('잠시 후 다시 시도해보세요') 보여지게 됩니다.(80976f5)

### Reference 
- [axios interceptor](https://axios-http.com/kr/docs/interceptors)
- [axios type](https://github.com/axios/axios/blob/v1.x/index.d.ts)

## todo 
- [ ] 서비스 코드에 ui에 보여주기 적절한 형태의 error message를 던지도록 개선 예정. 
- [ ] 다른 api service(book, memo) class 구현 
- [x] 현재 성욱님이 구현하신 코드에 이번 이슈에서 만든 api service 코드를 적용하지 않은 상태입니다. 이 부분도 따로 이슈로 올려서 pr 올리겠습니다. 
