### PR TITLE
Feature/#42 authentication routing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { Layout } from '@components/layout';
 import { ThemeProvider } from 'styled-components';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { RecoilRoot } from 'recoil';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 
@@ -24,8 +25,10 @@ function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <ThemeProvider theme={theme}>
-        <GlobalStyle />
-        <Layout />
+        <RecoilRoot>
+          <GlobalStyle />
+          <Layout />
+        </RecoilRoot>
       </ThemeProvider>
       <ReactQueryDevtools initialIsOpen={false} />
       <ToastContainer position="top-center" pauseOnFocusLoss theme="light" />

--- a/src/components/SignIn/index.tsx
+++ b/src/components/SignIn/index.tsx
@@ -1,22 +1,24 @@
-import { useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { useMutation } from '@tanstack/react-query';
+import { useRecoilState } from 'recoil';
 import styled from 'styled-components';
 
 import type { UserInfo, SignInInput } from '@projects/types/basic';
-import { authService } from '@apis/index';
+import { authService } from '@apis';
 import { EMAIL_REGEX, PAGE_URL, PASSWORD_REGEX } from '@constants';
 import { Button, SignContainer, SignInput } from '@components/common';
+import { loginState } from '@state/atom';
 
 function SignIn(): JSX.Element {
   const navigate = useNavigate();
-
+  const [isLoggedIn, setIsLoggedIn] = useRecoilState(loginState);
   const { mutate } = useMutation(authService.signIn);
   const onSubmit: SubmitHandler<SignInInput> = (userInfoData) => {
     mutate(userInfoData, {
       onSuccess(data) {
         if (data) {
+          setIsLoggedIn(true);
           navigate('/book/search');
         }
       },
@@ -28,12 +30,6 @@ function SignIn(): JSX.Element {
     handleSubmit,
     formState: { errors },
   } = useForm<UserInfo>();
-
-  useEffect(() => {
-    if (localStorage.getItem('token')) {
-      navigate('/book/search');
-    }
-  }, [navigate]);
 
   return (
     <SignContainer

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,27 +1,38 @@
-import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
 import styled from 'styled-components';
+
 import imgUrl from '@assets/logo.png';
 import { IoNotifications, IoPerson, IoLogOutOutline } from 'react-icons/io5';
 import { Button } from '@components/common';
 import { PAGE_URL } from '@constants';
+import { authService } from '@apis';
+import { loginState } from '@state/atom';
 
 export default function Header() {
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [isLoggedIn, setIsLoggedIn] = useRecoilState(loginState);
+
+  const handleLogout = () => {
+    authService.signOut();
+    setIsLoggedIn(false);
+  };
+
   return (
     <SHeader>
       <Logo to={PAGE_URL.ROOT}>
         <img src={imgUrl} alt="logo_icon" />
       </Logo>
+
       {isLoggedIn && (
         <SMenu>
           <IoNotifications />
           <SLink to={PAGE_URL.MYPAGE}>
             <IoPerson />
           </SLink>
-          <IoLogOutOutline />
+          <IoLogOutOutline onClick={handleLogout} />
         </SMenu>
       )}
+
       {!isLoggedIn && (
         <SMenu>
           <SLink to={PAGE_URL.SIGN_IN}>

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,8 +1,10 @@
 import styled from 'styled-components';
 import { Outlet } from 'react-router-dom';
+import useLoginState from '@hooks/useLoginState';
 import Header from './Header';
 
 export default function Layout() {
+  const { isLoggedIn } = useLoginState();
   return (
     <>
       <Header />

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -9,4 +9,5 @@ export const PAGE_URL = {
   POSTBOOK: '/book/register/:id',
   DETAILBOOKINFO: '/book/detail/:id',
   RECOMMENDEDBOOKS: '/book/recommended',
+  LIBRARY: '/book/library',
 };

--- a/src/hooks/useLoginState.ts
+++ b/src/hooks/useLoginState.ts
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+import { useRecoilState } from 'recoil';
+
+import { tokenRepository } from '@apis';
+import { loginState } from 'state/atom';
+import { isValidToken } from '@utils';
+
+const useLoginState = () => {
+  const [isLoggedIn, setIsLoggedIn] = useRecoilState(loginState);
+
+  useEffect(() => {
+    const token = tokenRepository.getToken();
+    setIsLoggedIn(isValidToken(token));
+  });
+
+  return { isLoggedIn };
+};
+export default useLoginState;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -19,11 +19,11 @@ const router = createBrowserRouter([
     path: PAGE_URL.ROOT,
     element: <App />,
     children: [
+      { index: true, element: <Landing /> },
+      { path: PAGE_URL.NOT_FOUND, element: <div>not found</div> },
       {
         element: <PublicRoute />,
         children: [
-          { index: true, element: <Landing /> },
-          { path: PAGE_URL.NOT_FOUND, element: <div>not found</div> },
           { path: PAGE_URL.SIGN_IN, element: <SignInPage /> },
           { path: PAGE_URL.SIGN_UP, element: <SignUpPage /> },
         ],

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,22 +10,37 @@ import {
   SignUpPage,
 } from '@pages';
 import RecommendedBooksPage from '@pages/RecommendedBooksPage';
-import App from './App';
+import { PrivateRoute, PublicRoute } from '@routes';
 import { PAGE_URL } from './constants';
+import App from './App';
 
 const router = createBrowserRouter([
   {
     path: PAGE_URL.ROOT,
     element: <App />,
     children: [
-      { index: true, element: <Landing /> },
-      { path: PAGE_URL.NOT_FOUND, element: <div>not found</div> },
-      { path: PAGE_URL.SEARCHBOOK, element: <SearchBookPage /> },
-      { path: PAGE_URL.POSTBOOK, element: <PostBookPage /> },
-      { path: PAGE_URL.DETAILBOOKINFO, element: <DetailBookInfoPage /> },
-      { path: PAGE_URL.SIGN_IN, element: <SignInPage /> },
-      { path: PAGE_URL.SIGN_UP, element: <SignUpPage /> },
-      { path: PAGE_URL.RECOMMENDEDBOOKS, element: <RecommendedBooksPage /> },
+      {
+        element: <PublicRoute />,
+        children: [
+          { index: true, element: <Landing /> },
+          { path: PAGE_URL.NOT_FOUND, element: <div>not found</div> },
+          { path: PAGE_URL.SIGN_IN, element: <SignInPage /> },
+          { path: PAGE_URL.SIGN_UP, element: <SignUpPage /> },
+        ],
+      },
+      {
+        element: <PrivateRoute />,
+        children: [
+          { path: PAGE_URL.SEARCHBOOK, element: <SearchBookPage /> },
+          { path: PAGE_URL.POSTBOOK, element: <PostBookPage /> },
+          { path: PAGE_URL.DETAILBOOKINFO, element: <DetailBookInfoPage /> },
+          {
+            path: PAGE_URL.RECOMMENDEDBOOKS,
+            element: <RecommendedBooksPage />,
+          },
+          { path: PAGE_URL.LIBRARY, element: <div>library</div> },
+        ],
+      },
     ],
   },
 ]);

--- a/src/pages/SignInPage.tsx
+++ b/src/pages/SignInPage.tsx
@@ -1,8 +1,7 @@
-import SininIn from '@components/SignIn';
-import React from 'react';
+import SignIn from '@components/SignIn';
 
 function SignInPage() {
-  return <SininIn />;
+  return <SignIn />;
 }
 
 export default SignInPage;

--- a/src/routes/PrivateRoute.tsx
+++ b/src/routes/PrivateRoute.tsx
@@ -1,0 +1,14 @@
+import { Navigate, Outlet } from 'react-router-dom';
+import useLoginState from '@hooks/useLoginState';
+import { PAGE_URL } from '@constants';
+import { useRecoilState } from 'recoil';
+import { loginState } from '../state/atom';
+
+function PrivateRoute() {
+  const [isLoggedIn] = useRecoilState(loginState);
+
+  if (!isLoggedIn) return <Navigate to={PAGE_URL.SIGN_IN} />;
+
+  return <Outlet />;
+}
+export default PrivateRoute;

--- a/src/routes/PrivateRoute.tsx
+++ b/src/routes/PrivateRoute.tsx
@@ -1,8 +1,8 @@
 import { Navigate, Outlet } from 'react-router-dom';
-import useLoginState from '@hooks/useLoginState';
-import { PAGE_URL } from '@constants';
 import { useRecoilState } from 'recoil';
-import { loginState } from '../state/atom';
+
+import { PAGE_URL } from '@constants';
+import { loginState } from '@state/atom';
 
 function PrivateRoute() {
   const [isLoggedIn] = useRecoilState(loginState);

--- a/src/routes/PublicRoute.tsx
+++ b/src/routes/PublicRoute.tsx
@@ -1,0 +1,13 @@
+import { Outlet, Navigate } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
+
+import { loginState } from 'state/atom';
+import { PAGE_URL } from '../constants/path';
+
+function PublicRoute() {
+  const [isLoggedIn] = useRecoilState(loginState);
+
+  if (isLoggedIn) return <Navigate to={PAGE_URL.LIBRARY} />;
+  return <Outlet />;
+}
+export default PublicRoute;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,0 +1,2 @@
+export { default as PrivateRoute } from './PrivateRoute';
+export { default as PublicRoute } from './PublicRoute';

--- a/src/state/atom.ts
+++ b/src/state/atom.ts
@@ -1,0 +1,6 @@
+import { atom, type RecoilState } from 'recoil';
+
+export const loginState: RecoilState<boolean> = atom({
+  key: 'isLoggedIn',
+  default: false,
+});

--- a/src/utils/isValidToken.ts
+++ b/src/utils/isValidToken.ts
@@ -7,9 +7,12 @@ type JwtPayload = {
   email: string;
 };
 
-export const isValidToken = (token: string) => {
-  const { exp: expireTime } = jwtDecode<JwtPayload>(token);
-  const currentTime = Math.floor(Date.now() / 1000);
+export const isValidToken = (token: string | null) => {
+  if (token) {
+    const { exp: expireTime } = jwtDecode<JwtPayload>(token);
+    const currentTime = Math.floor(Date.now() / 1000);
 
-  return currentTime < expireTime;
+    return currentTime < expireTime;
+  }
+  return false;
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,8 @@
       "@hooks": ["hooks"],
       "@pages/*": ["pages/*"],
       "@pages": ["pages"],
+      "@routes": ["routes"],
+      "@state/*": ["state/*"],
       "@styles/*": ["styles/*"],
       "@styles": ["styles"],
       "@theme/*": ["theme/*"],


### PR DESCRIPTION
## 🔗 ISSUE NUMBER
<!-- closed #[issue-number]로 작성하면 이슈가 닫히고, 링크도 연결할 수 있어요 -->

- closed #42 

## 🙌 구현 사항
- global state 추가- 로그인 여부
- private, public page routing
- header 컴포넌트 수정 

## 📝 구현 설명
로그인 여부에 따라서 페이지 라우팅 처리와 header 컴포넌트 ui가 변경되어야하기 때문에 로그인 상태(boolean)를 recoil을 사용해서 전역상태로 저장했습니다. a9a71db 로그인, 로그아웃 시에 해당 상태 변화 로직을 추가했습니다. 7e03031

이 전역상태(로그인 여부)를 이용해서 header 컴포넌트의 ui를 변경, 라우팅 처리를 추가했습니다.  현재 상태는 로그인하지 않은 사용자는 랜딩, 로그인, 회원가입 페이지 이외의 페이지에 진입할 수 없고 로그인한 사용자는 로그인, 회원가입 페이지에 진입할 수 없습니다. 
```typescript
const router = createBrowserRouter([
  {
    path: PAGE_URL.ROOT,
    element: <App />,
    children: [
      { index: true, element: <Landing /> },
      { path: PAGE_URL.NOT_FOUND, element: <div>not found</div> },
      {
        element: <PublicRoute />,
        children: [
          { path: PAGE_URL.SIGN_IN, element: <SignInPage /> },
          { path: PAGE_URL.SIGN_UP, element: <SignUpPage /> },
        ],
      },
      {
        element: <PrivateRoute />,
        children: [
          { path: PAGE_URL.SEARCHBOOK, element: <SearchBookPage /> },
          { path: PAGE_URL.POSTBOOK, element: <PostBookPage /> },
          { path: PAGE_URL.DETAILBOOKINFO, element: <DetailBookInfoPage /> },
          {
            path: PAGE_URL.RECOMMENDEDBOOKS,
            element: <RecommendedBooksPage />,
          },
          { path: PAGE_URL.LIBRARY, element: <div>library</div> },
        ],
      },
    ],
  },
]);
```
페이지가 새로고침될때 로컬스토리지에 남아있는 토큰을 검사하여 전역 상태(로그인 여부)를 변화시키는 useLoginState이라는 커스텀 훅을 만들었고, 이를 layout 컴포넌트에 연결시켜뒀습니다. 14e4ea2

