### PR TITLE
Feature/#20 SignUp page

### DIFF
--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,5 +1,3 @@
-import axios from 'axios';
-import { UserInfo } from '@projects/types/basic';
 import { TokenRepositoryImpl } from './tokenRepository';
 import { HttpClientImpl } from './httpClient';
 import { HttpClientAuthImpl } from './httpClientAuth';

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -19,12 +19,3 @@ export const profileService = new ProfileServiceImpl(
   httpClientAuth,
   tokenRepository
 );
-// 회원가입
-export const postSignUp = async (
-  SignUpuserInfoData: Omit<UserInfo, 'password_confirm'>
-) => {
-  const response = await axios.post(`${BASE_URL}/join`, SignUpuserInfoData, {
-    withCredentials: true,
-  });
-  return response;
-};

--- a/src/components/SignIn/index.tsx
+++ b/src/components/SignIn/index.tsx
@@ -32,11 +32,7 @@ function SignIn(): JSX.Element {
   } = useForm<UserInfo>();
 
   return (
-    <SignContainer
-      width="22rem"
-      height="22rem"
-      onSubmit={handleSubmit(onSubmit)}
-    >
+    <SignContainer height="22rem" onSubmit={handleSubmit(onSubmit)}>
       <SignInput
         label="이메일"
         id="email"

--- a/src/components/SignUp/index.tsx
+++ b/src/components/SignUp/index.tsx
@@ -6,7 +6,7 @@ import { SignUpInput, UserInfo } from '@projects/types/basic';
 import { Button, SignContainer, SignInput } from '@components/common';
 import { EMAIL_REGEX, PASSWORD_REGEX } from '@constants';
 import { useRef } from 'react';
-import { toast, ToastContainer } from 'react-toastify';
+import { toast } from 'react-toastify';
 
 function SignUp() {
   const navigate = useNavigate();

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -23,6 +23,7 @@ export default function Button({
   size,
   children,
   className,
+  type,
 }: Props) {
   return (
     <SButton
@@ -31,6 +32,7 @@ export default function Button({
       styleType={styleType}
       size={size}
       className={className}
+      type={type}
     >
       {children}
     </SButton>

--- a/src/components/common/SignContainer.tsx
+++ b/src/components/common/SignContainer.tsx
@@ -3,24 +3,18 @@ import styled from 'styled-components';
 
 type Props = {
   children: React.ReactNode;
-  width: string;
   height: string;
   onSubmit: React.FormEventHandler<HTMLFormElement>;
 };
-export default function SignContainer({
-  children,
-  width,
-  height,
-  onSubmit,
-}: Props) {
+export default function SignContainer({ children, height, onSubmit }: Props) {
   return (
-    <SContainer width={width} height={height}>
+    <SContainer height={height}>
       <form onSubmit={onSubmit}>{children}</form>
     </SContainer>
   );
 }
 
-const SContainer = styled.section<Pick<Props, 'width' | 'height'>>`
+const SContainer = styled.section<Pick<Props, 'height'>>`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -28,7 +22,8 @@ const SContainer = styled.section<Pick<Props, 'width' | 'height'>>`
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  width: ${(props) => props.width};
+  margin-top: 2rem;
+  width: 22rem;
   height: ${(props) => props.height};
   border-radius: 0.25rem;
   box-shadow: 0rem 0rem 0.25rem 0rem rgba(0 0 0 / 20%);
@@ -40,6 +35,6 @@ const SContainer = styled.section<Pick<Props, 'width' | 'height'>>`
     display: flex;
     flex-direction: column;
     justify-content: space-around;
-    align-items: flex-start;
+    align-items: flex-end;
   }
 `;

--- a/src/types/basic.ts
+++ b/src/types/basic.ts
@@ -15,18 +15,22 @@ export interface SearchBookInfo {
   publisher: string;
 }
 
-type SignInputLabel = '이름' | '이메일' | '비밀번호' | '비밀번호 확인';
+type SignInputLabel =
+  | '이름'
+  | '이메일'
+  | '이메일 인증 번호'
+  | '비밀번호'
+  | '비밀번호 확인';
 export interface UserInfo {
   name: string;
   email: string;
+  authenticationCode: string;
   password: string;
   password_confirm: string;
 }
 export type Profile = Pick<UserInfo, 'email' | 'name'>;
 export type SignInInput = Pick<UserInfo, 'email' | 'password'>;
-export type SignUpInput = Omit<UserInfo, 'password_confirm'> & {
-  authenticationCode: string;
-};
+export type SignUpInput = Omit<UserInfo, 'password_confirm'>;
 
 export type RecommendSort = 'best-seller' | 'item-new-special';
 


### PR DESCRIPTION
## 🔗 ISSUE NUMBER
<!-- closed #[issue-number]로 작성하면 이슈가 닫히고, 링크도 연결할 수 있어요 -->

- closed #38 

## 🙌 구현 사항
- SignContainer components ui 수정
- 회원가입 이메일 인증 기능 구현

## 📝 구현 설명
-----
### SignContainer components ui 수정

기존 SignContainer는 `width` 와 `height` 을 props로 받고 있었지만, `width` 변경이 필요없기 때문에 22rem 으로 고정한 후 
`Header` 와의 간격을 두기 위해 `margin - top` 을 2rem 추가했습니다. 258d99a

<img width="662" alt="image" src="https://user-images.githubusercontent.com/27681985/218357760-5cf8f525-4fa4-4724-abb1-33783a93f4e2.png"> 


### 회원가입 이메일 인증 기능 구현
이메일 인증 번호 요청 `Button` components 와 이메일 인증 번호 `SignInput` components 를 추가했습니다. cee1b2d

 1.  `Button` compoents 수정
이메일 인증 번호 요청 `Button` 클릭 시 submit 되는 기능을 막기 위해 Button components의 props로 type을 추가했습니다. 
<img width="367" alt="image" src="https://user-images.githubusercontent.com/27681985/218359028-08c159e7-8847-4a85-b416-28a29375f12c.png">

이메일 인증 번호 요청 `Button` components 클릭 시 동작하는 `emailHandleClick`  함수를 구현했습니다.
버튼 클릭 시 `email` 값에 대한 유효성 검사를 진행한 후 `getEmailAuthCode` 메서드를 호출합니다.

```typescript
 const emailHandleClick = async () => {
    const value = getValues('email');
    if (EMAIL_REGEX.test(value)) {
      const result = await authService.getEmailAuthCode(value);
      toast.success(result);
    } else {
      toast.error('이메일 형식이어야 합니다.');
    }
  };
```

 2. 이메일 인증 번호 `SignInput` components 추가
이메일 인증 번호를 입력하는 Input 창을 추가했습니다. 유효성 검사는 **숫자 6자리 이상**을 허용하는 정규표현식을 사용했습니다.

```typescript
<SignInput
        id="authenticationCode"
        label="이메일 인증 번호"
        type="text"
        placeholder="이메일 인증 번호"
        pattern={/^\d{6,}$/}
        register={register}
        errors={errors}
        errMessage="이메일 인증 번호를 입력해주세요."
        required
      />

```
