### PR TITLE
🐛 fix: [#51] 모달 내부의 submit 이벤트 버블링 이슈 해결(react-hook-form 관련)

### DIFF
--- a/src/components/SignIn/SearchPassword.tsx
+++ b/src/components/SignIn/SearchPassword.tsx
@@ -33,7 +33,12 @@ function SearchPassword() {
     <>
       <SSearchPw onClick={toggle}>비밀번호 찾기</SSearchPw>
       <Modal isOpen={isOpen} closeModal={toggle}>
-        <Sform onSubmit={handleSubmit(onSubmit)}>
+        <Sform
+          onSubmit={(e) => {
+            e.stopPropagation();
+            handleSubmit(onSubmit)(e);
+          }}
+        >
           <div>이메일 주소를 입력해주세요</div>
           <SignInput
             id="email"


### PR DESCRIPTION
## 🔗 ISSUE NUMBER
<!-- closed #[issue-number]로 작성하면 이슈가 닫히고, 링크도 연결할 수 있어요 -->

- closed #51 

## 🙌 구현 사항
- #49  에 남긴대로 ([링크](https://github.com/Team-Seollem/seollem-fe/pull/49#issuecomment-1446208858)) 모달 내부에서 발생한 폼 제출 이벤트가 발생하면, signIn 페이지 내의 폼 이벤트도 함께 제출되는 이슈가 발견됐습니다. 
처음에는 모달 컴포넌트 구현 상에서 문제라고 생각해서 간단하게 [테스트](https://codesandbox.io/s/modal-2p62qm)해보았는데 이벤트가 버블링되지 않았습니다. 
react-hook-form 관련 이슈로 범위를 좁혀 찾아보던 중 관련된 [디스커션](https://github.com/react-hook-form/react-hook-form/discussions/3704)을 발견했고 여기에서 제시된 방법으로 이슈를 해결했습니다. 

## 📝 구현 설명
(위 링크의 디스커션에서 선택된 답변의 설명 + chatGPT의 도움으로 애매하게 이해한 내용을 설명해보겠습니다..!)
useForm hook에서 반환된 handleSubmit 함수는, 폼 제출(submit) 이벤트가 발생할 때 실행되는 콜백 함수이고,  handleSubmit 함수의 콜백으로 전달한 onSubmit은, 폼 제출(submit) 이벤트 발생 시에 비동기적으로 호출됩니다.  

onSubmit 함수가 실행될 시점에는 이미 Synthetic 'submit' 이벤트가 발생하고, 이벤트가 이미 전파된 상태입니다. 때문에 event.stopPropagation()을 onSubmit 함수 내부에서 호출해도, 이미 전파된 Synthetic 이벤트를 중지할 수 없습니다.

이벤트 전파를 막기 위해서는, 이벤트 핸들러가 호출되는 시점에서 이벤트 버블링을 막아야하고, onSubmit 함수가 실행되기 바로 이전에, 'submit' 이벤트가 전파되는 것을 막기 위해 폼의 onSubmit 핸들러에서 먼저 e.stopPropagation()을 호출하고, 그 다음에handleSubmit(onSubmit)(e)을 호출하도록 수정했습니다.