### PR TITLE
Feature/#61 common component

### DIFF
--- a/src/components/MemoBooks/MemoBookList.tsx
+++ b/src/components/MemoBooks/MemoBookList.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { BookCoverItem, Pagination } from '@components/common';
+import Tooltip from '@components/common/Tooltip';
 import useMemoBooks from './hooks/useMemoBooks';
 import * as S from './styles';
 import SkeletonBookList from './SkeletonBookList';
@@ -20,11 +21,12 @@ export default function MemoBookList() {
       ) : (
         <S.Wrapper>
           {memoBooks.map((item) => (
-            <BookCoverItem
-              key={item.bookId}
-              src={item.cover}
-              onClick={() => handleClickMemoBookCover(item.bookId)}
-            />
+            <Tooltip key={item.bookId} content={`${item.memoCount}개의 메모`}>
+              <BookCoverItem
+                src={item.cover}
+                onClick={() => handleClickMemoBookCover(item.bookId)}
+              />
+            </Tooltip>
           ))}
         </S.Wrapper>
       )}

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -1,0 +1,63 @@
+import { useState, useRef } from 'react';
+import styled from 'styled-components';
+import ReactPortal from './ReactPortal';
+
+type Props = {
+  target: React.ReactNode;
+  children: React.ReactNode;
+  offsetX?: number;
+  offsetY?: number;
+};
+
+export default function Dropdown({
+  target,
+  children,
+  offsetX = -90,
+  offsetY = -5,
+}: Props) {
+  const targetRef = useRef<HTMLDivElement>(null);
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const toggleMenu = () => {
+    setIsOpen(!isOpen);
+  };
+  const getCoordinates = () => {
+    const element = targetRef.current;
+    if (!element) {
+      return { left: 0, top: 0 };
+    }
+    const targetRect = element.getBoundingClientRect();
+
+    const left = targetRect.left + offsetX;
+    const top = targetRect.bottom + offsetY;
+    return { left, top };
+  };
+
+  const position = getCoordinates();
+  return (
+    <Wrapper onMouseEnter={toggleMenu} onMouseLeave={toggleMenu}>
+      <ButtonWrapper ref={targetRef}>{target}</ButtonWrapper>
+      <ReactPortal wrapperId="dropdown-root">
+        {isOpen && (
+          <DropdownWrapper left={position.left} top={position.top}>
+            {children}
+          </DropdownWrapper>
+        )}
+      </ReactPortal>
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  position: relative;
+`;
+
+const ButtonWrapper = styled.div`
+  cursor: pointer;
+`;
+
+const DropdownWrapper = styled.div<{ top: number; left: number }>`
+  position: absolute;
+  z-index: 2;
+  top: ${({ top }) => `${top}px`};
+  left: ${({ left }) => `${left}px`};
+`;

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useCallback } from 'react';
 import styled from 'styled-components';
 import ReactPortal from './ReactPortal';
 
@@ -20,7 +20,7 @@ export default function Dropdown({
   const toggleMenu = () => {
     setIsOpen(!isOpen);
   };
-  const getCoordinates = () => {
+  const getCoordinates = useCallback(() => {
     const element = targetRef.current;
     if (!element) {
       return { left: 0, top: 0 };
@@ -30,7 +30,7 @@ export default function Dropdown({
     const left = targetRect.left + offsetX;
     const top = targetRect.bottom + offsetY;
     return { left, top };
-  };
+  }, [offsetX, offsetY]);
 
   const position = getCoordinates();
   return (

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -56,7 +56,7 @@ const ButtonWrapper = styled.div`
 `;
 
 const DropdownWrapper = styled.div<{ top: number; left: number }>`
-  position: absolute;
+  position: fixed;
   z-index: 2;
   top: ${({ top }) => `${top}px`};
   left: ${({ left }) => `${left}px`};

--- a/src/components/common/Tooltip.tsx
+++ b/src/components/common/Tooltip.tsx
@@ -1,0 +1,63 @@
+import { useState, useRef, useCallback } from 'react';
+import styled from 'styled-components';
+import ReactPortal from './ReactPortal';
+
+type Props = {
+  children: React.ReactNode;
+  content: string;
+};
+
+export default function Tooltip({ children, content }: Props) {
+  const targetRef = useRef<HTMLDivElement>(null);
+  const [isVisible, setIsVisible] = useState(false);
+  const toggleVisibility = () => {
+    setIsVisible(!isVisible);
+  };
+
+  const getCoordinates = useCallback(() => {
+    const element = targetRef.current;
+    if (!element) {
+      return { x: 0, y: 0 };
+    }
+    const targetRect = element.getBoundingClientRect();
+
+    const x = targetRect.left + targetRect.width / 2;
+    const y = targetRect.top + targetRect.height / 2;
+    return { x, y };
+  }, [targetRef]);
+
+  const position = getCoordinates();
+  return (
+    <Wrapper
+      ref={targetRef}
+      onMouseEnter={toggleVisibility}
+      onMouseLeave={toggleVisibility}
+    >
+      {children}
+      <ReactPortal wrapperId="tooltip-root">
+        {isVisible && (
+          <Text left={position.x} top={position.y}>
+            {content}
+          </Text>
+        )}
+      </ReactPortal>
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  position: relative;
+`;
+
+const Text = styled.p<{ top: number; left: number }>`
+  position: absolute;
+  z-index: 1;
+  top: ${({ top }) => `${top}px`};
+  left: ${({ left }) => `${left}px`};
+  padding: 0.3rem;
+  border-radius: 0.3rem;
+  width: 4rem;
+  font-size: ${({ theme }) => theme.fontSize.sm};
+  background-color: ${({ theme }) => theme.color.gray01};
+  color: ${({ theme }) => theme.color.white};
+`;

--- a/src/components/common/Tooltip.tsx
+++ b/src/components/common/Tooltip.tsx
@@ -17,13 +17,13 @@ export default function Tooltip({ children, content }: Props) {
   const getCoordinates = useCallback(() => {
     const element = targetRef.current;
     if (!element) {
-      return { x: 0, y: 0 };
+      return { left: 0, top: 0 };
     }
     const targetRect = element.getBoundingClientRect();
 
-    const x = targetRect.left + targetRect.width / 2;
-    const y = targetRect.top + targetRect.height / 2;
-    return { x, y };
+    const left = targetRect.left + targetRect.width / 2;
+    const top = targetRect.top + targetRect.height / 2;
+    return { left, top };
   }, [targetRef]);
 
   const position = getCoordinates();
@@ -36,7 +36,7 @@ export default function Tooltip({ children, content }: Props) {
       {children}
       <ReactPortal wrapperId="tooltip-root">
         {isVisible && (
-          <Text left={position.x} top={position.y}>
+          <Text left={position.left} top={position.top}>
             {content}
           </Text>
         )}

--- a/src/components/layout/PrivateHeader.tsx
+++ b/src/components/layout/PrivateHeader.tsx
@@ -1,17 +1,23 @@
 import { useNavigate } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
 
-import { IoNotifications, IoPerson, IoLogOutOutline } from 'react-icons/io5';
+import { IoNotifications, IoMenu } from 'react-icons/io5';
 
 import { PAGE_URL } from '@constants';
 import { authService } from '@apis';
 import { loginState } from '@state/atom';
+import Dropdown from '@components/common/DropDown';
+import styled from 'styled-components';
 import * as S from './styles';
 import Logo from './Logo';
 
 export default function PrivateHeader() {
   const setIsLoggedIn = useSetRecoilState(loginState);
   const navigate = useNavigate();
+
+  const handleMyPage = () => {
+    navigate(PAGE_URL.MYPAGE);
+  };
 
   const handleLogout = () => {
     authService.signOut();
@@ -24,11 +30,16 @@ export default function PrivateHeader() {
       <Logo to={PAGE_URL.LIBRARY} />
 
       <S.Menu>
-        <IoNotifications />
-        <S.MenuLink to={PAGE_URL.MYPAGE}>
-          <IoPerson />
-        </S.MenuLink>
-        <IoLogOutOutline onClick={handleLogout} />
+        <Dropdown target={<IoMenu />}>
+          <S.DropdownMenuWrapper>
+            <S.DropdownMenuItem onClick={handleMyPage}>
+              마이 페이지
+            </S.DropdownMenuItem>
+            <S.DropdownMenuItem onClick={handleLogout}>
+              로그아웃
+            </S.DropdownMenuItem>
+          </S.DropdownMenuWrapper>
+        </Dropdown>
       </S.Menu>
     </S.Header>
   );

--- a/src/components/layout/PrivateHeader.tsx
+++ b/src/components/layout/PrivateHeader.tsx
@@ -1,13 +1,11 @@
 import { useNavigate } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
-
-import { IoNotifications, IoMenu } from 'react-icons/io5';
+import { IoMenu } from 'react-icons/io5';
 
 import { PAGE_URL } from '@constants';
 import { authService } from '@apis';
 import { loginState } from '@state/atom';
 import Dropdown from '@components/common/DropDown';
-import styled from 'styled-components';
 import * as S from './styles';
 import Logo from './Logo';
 
@@ -30,6 +28,7 @@ export default function PrivateHeader() {
       <Logo to={PAGE_URL.LIBRARY} />
 
       <S.Menu>
+        {/* <IoNotifications /> */}
         <Dropdown target={<IoMenu />}>
           <S.DropdownMenuWrapper>
             <S.DropdownMenuItem onClick={handleMyPage}>

--- a/src/components/layout/styles.ts
+++ b/src/components/layout/styles.ts
@@ -3,9 +3,10 @@ import { Link } from 'react-router-dom';
 import { Button } from '@components/common';
 
 export const Header = styled.header`
-  position: sticky;
+  position: fixed;
   top: 0;
   z-index: 1;
+  width: 100%;
   padding: 0 1rem;
   height: 3.75rem;
   display: flex;
@@ -14,6 +15,7 @@ export const Header = styled.header`
   background-color: ${({ theme }) => theme.color.white};
   box-shadow: 0 4px 6px rgb(32 33 36 / 10%);
   min-width: 375px;
+  max-width: 40rem;
 `;
 
 export const Menu = styled.div`
@@ -51,7 +53,8 @@ export const DropdownMenuItem = styled.div`
 `;
 
 export const Main = styled.main`
-  margin: 0.9rem 0.75rem 1.25rem 0.75rem;
+  margin: 0 0.75rem 1.25rem 0.75rem;
+  padding-top: 4.5rem;
   padding-bottom: 4rem;
   display: flex;
   flex-direction: column;

--- a/src/components/layout/styles.ts
+++ b/src/components/layout/styles.ts
@@ -6,7 +6,7 @@ export const Header = styled.header`
   position: sticky;
   top: 0;
   z-index: 1;
-  padding: 0 1rem 0 0.6rem;
+  padding: 0 1rem;
   height: 3.75rem;
   display: flex;
   justify-content: space-between;
@@ -23,7 +23,7 @@ export const Menu = styled.div`
     margin: 0 0.4rem;
     padding: 0.6rem auto;
     font-size: 1.8rem;
-    color: ${({ theme }) => theme.color.primary};
+    color: ${({ theme }) => theme.color.gray02};
   }
 `;
 
@@ -33,6 +33,21 @@ export const MenuLink = styled(Link)`
 
 export const HeaderButton = styled(Button)`
   margin: 0 0.4rem;
+`;
+
+export const DropdownMenuWrapper = styled.ul`
+  background-color: white;
+  width: 7rem;
+  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.1);
+  border-radius: 0.5rem;
+  cursor: pointer;
+`;
+
+export const DropdownMenuItem = styled.div`
+  padding: 0.5rem 1rem;
+  &:hover {
+    background-color: ${({ theme }) => theme.color.gray04};
+  }
 `;
 
 export const Main = styled.main`

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,10 +1,10 @@
 import { useState } from 'react';
 
 export default function useModal() {
-  const [isOpen, setIsShowing] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
 
   const toggle = () => {
-    setIsShowing(!isOpen);
+    setIsOpen(!isOpen);
   };
 
   return { isOpen, toggle };


### PR DESCRIPTION
## 🔗 ISSUE NUMBER
<!-- closed #[issue-number]로 작성하면 이슈가 닫히고, 링크도 연결할 수 있어요 -->

- closed #61

## 🙌 구현 사항
- Tooltip component, Dropdown component 구현
- header, memobooks page ui 추가

## 📝 구현 설명
### Tooltip component, Dropdown component 구현
두 컴포넌트 모두 portal을 이용해서 구현했습니다. 
https://github.com/Team-Seollem/seollem-fe/blob/46d7ec0a5611274dc41e7b465cc717563c8dd4ac/src/components/common/Tooltip.tsx#L10-L46
ref의 좌표값을 [getBoundingClientRect()](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect)을 통해서 dropdown, tooltip 컴포넌트가 보여질 정합니다. 

### header, memobooks page에 추가 
<img width="645" alt="header" src="https://user-images.githubusercontent.com/96093996/227885058-73178660-b889-4816-878a-8a56d08ada5e.png">
<img width="650" alt="memobooks" src="https://user-images.githubusercontent.com/96093996/227885339-87356735-4a4e-4028-8f3e-617f3cea4f9c.png">

### layout 수정 
Header 컴포넌트에 dropdown의 위치를 고정시키기 위해서 Header와 Main 의 css를 수정했습니다. 
https://github.com/Team-Seollem/seollem-fe/blob/46d7ec0a5611274dc41e7b465cc717563c8dd4ac/src/components/layout/styles.ts#L5-L19
https://github.com/Team-Seollem/seollem-fe/blob/46d7ec0a5611274dc41e7b465cc717563c8dd4ac/src/components/layout/styles.ts#L55-L61