### PR TITLE
Feature/#68 fix routing

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -18,32 +18,116 @@ import { PAGE_URL } from './constants';
 
 const Router = createBrowserRouter([
   {
-    element: <PublicRoute />,
-    children: [
-      { path: PAGE_URL.ROOT, element: <Landing /> },
-      { path: PAGE_URL.NOT_FOUND, element: <div>not found</div> },
-      { path: PAGE_URL.SIGN_IN, element: <SignInPage /> },
-      { path: PAGE_URL.SIGN_UP, element: <SignUpPage /> },
-    ],
+    path: PAGE_URL.ROOT,
+    element: (
+      <PublicRoute>
+        <Landing />
+      </PublicRoute>
+    ),
   },
   {
-    element: <PrivateRoute />,
-    children: [
-      { path: PAGE_URL.SEARCHBOOK, element: <SearchBookPage /> },
-      { path: PAGE_URL.POSTBOOK, element: <PostBookPage /> },
-      { path: PAGE_URL.DETAILBOOKINFO, element: <DetailBookInfoPage /> },
-      {
-        path: PAGE_URL.RECOMMENDEDBOOKS,
-        element: <RecommendedBooksPage />,
-      },
-      { path: PAGE_URL.LIBRARY, element: <Library /> },
-      { path: PAGE_URL.LIBRARYBOOK, element: <LibraryBook /> },
-      { path: PAGE_URL.MEMO_FORM, element: <MemoForm /> },
-      { path: PAGE_URL.EDIT_MEMO, element: <MemoForm /> },
-      { path: PAGE_URL.MEMO_BOOKS, element: <MemoBooks /> },
-      { path: PAGE_URL.MEMO_BOOK_DETAIL, element: <MemoBookDetail /> },
-    ],
+    path: PAGE_URL.NOT_FOUND,
+    element: (
+      <PublicRoute>
+        <div>Page Not Found</div>
+      </PublicRoute>
+    ),
+  },
+  {
+    path: PAGE_URL.SIGN_IN,
+    element: (
+      <PublicRoute>
+        <SignInPage />
+      </PublicRoute>
+    ),
+  },
+  {
+    path: PAGE_URL.SIGN_UP,
+    element: (
+      <PublicRoute>
+        <SignUpPage />
+      </PublicRoute>
+    ),
+  },
+  {
+    path: PAGE_URL.SEARCHBOOK,
+    element: (
+      <PrivateRoute>
+        <SearchBookPage />
+      </PrivateRoute>
+    ),
+  },
+  {
+    path: PAGE_URL.POSTBOOK,
+    element: (
+      <PrivateRoute>
+        <PostBookPage />
+      </PrivateRoute>
+    ),
+  },
+  {
+    path: PAGE_URL.DETAILBOOKINFO,
+    element: (
+      <PrivateRoute>
+        <DetailBookInfoPage />
+      </PrivateRoute>
+    ),
+  },
+  {
+    path: PAGE_URL.RECOMMENDEDBOOKS,
+    element: (
+      <PrivateRoute>
+        <RecommendedBooksPage />
+      </PrivateRoute>
+    ),
+  },
+  {
+    path: PAGE_URL.LIBRARY,
+    element: (
+      <PrivateRoute>
+        <Library />
+      </PrivateRoute>
+    ),
+  },
+  {
+    path: PAGE_URL.LIBRARYBOOK,
+    element: (
+      <PrivateRoute>
+        <LibraryBook />
+      </PrivateRoute>
+    ),
+  },
+  {
+    path: PAGE_URL.MEMO_FORM,
+    element: (
+      <PrivateRoute>
+        <MemoForm />
+      </PrivateRoute>
+    ),
+  },
+  {
+    path: PAGE_URL.EDIT_MEMO,
+    element: (
+      <PrivateRoute>
+        <MemoForm />
+      </PrivateRoute>
+    ),
+  },
+  {
+    path: PAGE_URL.MEMO_BOOKS,
+    element: (
+      <PrivateRoute>
+        <MemoBooks />
+      </PrivateRoute>
+    ),
+  },
+  {
+    path: PAGE_URL.MEMO_BOOK_DETAIL,
+    element: (
+      <PrivateRoute>
+        <MemoBookDetail />
+      </PrivateRoute>
+    ),
   },
 ]);
-
 export default Router;

--- a/src/apis/httpClientAuth.ts
+++ b/src/apis/httpClientAuth.ts
@@ -16,10 +16,11 @@ const handleUnauthorizedError = (
   error: AxiosError,
   tokenRepository: TokenRepositoryImpl
 ) => {
-  if (error.response?.status === 403) {
+  if (error.response?.status === 401) {
+    window.location.href = '/auth/signin';
     tokenRepository.removeToken();
   }
-  throw error;
+  return Promise.reject(error);
 };
 
 export class HttpClientAuthImpl extends HttpClientImpl implements HttpClient {

--- a/src/components/layout/PrivateRoute.tsx
+++ b/src/components/layout/PrivateRoute.tsx
@@ -1,20 +1,22 @@
-import { Navigate, Outlet } from 'react-router-dom';
+import { Navigate } from 'react-router-dom';
 
 import useLoginState from '@hooks/useLoginState';
 import { PAGE_URL } from '@constants';
 import { PrivateHeader, GNB } from '@components/layout';
 import * as S from '@components/layout/styles';
 
-function PrivateRoute() {
+type Props = {
+  children: React.ReactNode;
+};
+
+function PrivateRoute({ children }: Props) {
   const { isLoggedIn } = useLoginState();
   if (!isLoggedIn) return <Navigate to={PAGE_URL.SIGN_IN} />;
 
   return (
     <>
       <PrivateHeader />
-      <S.Main>
-        <Outlet />
-      </S.Main>
+      <S.Main>{children}</S.Main>
       <GNB />
     </>
   );

--- a/src/components/layout/PublicRoute.tsx
+++ b/src/components/layout/PublicRoute.tsx
@@ -1,21 +1,22 @@
-import { Outlet, Navigate } from 'react-router-dom';
+import { Navigate } from 'react-router-dom';
 
 import useLoginState from '@hooks/useLoginState';
 import { PAGE_URL } from '@constants';
 import { PublicHeader } from '@components/layout';
 import * as S from '@components/layout/styles';
 
-function PublicRoute() {
-  const { isLoggedIn } = useLoginState();
+type Props = {
+  children: React.ReactNode;
+};
 
+function PublicRoute({ children }: Props) {
+  const { isLoggedIn } = useLoginState();
   if (isLoggedIn) return <Navigate to={PAGE_URL.LIBRARY} />;
 
   return (
     <>
       <PublicHeader />
-      <S.Main>
-        <Outlet />
-      </S.Main>
+      <S.Main>{children}</S.Main>
     </>
   );
 }


### PR DESCRIPTION
## 🔗 ISSUE NUMBER
<!-- closed #[issue-number]로 작성하면 이슈가 닫히고, 링크도 연결할 수 있어요 -->

- closed #68

## 🙌 구현 사항
- 로그인 권한(유효한 토큰을 가지고 있는 유저)에 따라서 페이지 라우팅이 이루어지도록 PrivateRoute, PublicRoute 수정
- axios interceptor의 권한 관련 에러 처리 수정 

## 📝 구현 설명
### ✅ 로그인 권한(유효한 토큰을 가지고 있는 유저)에 따라서 페이지 라우팅이 이루어지도록 PrivateRoute, PublicRoute 수정
권한이 없는 사용자가 privateRoute 아래의 페이지들에 접근을 아예하지 못하도록 막고 싶었는데, 제가 지금까지 구현한 권한 체크 로직이 페이지 이동시마다 확인하는 형태가 아니라는 것을 파악해서 수정했습니다. react-router-dom의 Outlet을 사용해서 페이지 렌더링 하는 것에서 children을 props로 받는 형태로 수정했습니다. 라우터를 정의한 부분(Router.tsx)의 코드가 살짝 지저분한데 이 부분은 이슈 생성해서 수정하겠습니다! 
https://github.com/Team-Seollem/seollem-fe/blob/fb02548dd481b461e02112353a3109946424ebd0/src/components/layout/PrivateRoute.tsx#L16-L23

https://github.com/Team-Seollem/seollem-fe/blob/fb02548dd481b461e02112353a3109946424ebd0/src/Router.tsx#L53-L68

### ✅ axios interceptor의 권한 관련 에러 처리 수정 
저희 서버에서 유효하지 않은 토큰 값에 대한 에러 코드가 401로 변경되어서 수정했고, 로그인 페이지로 리다이렉트하는 로직을 추가했습니다. 
그리고 401을 제외한 오류에 대한 처리를 `throw error` ->  `return Promise.reject(error)`로 수정했습니다. 401에러를 제외한 에러에 대해서는  바로 에러를 던지지 않고 함수를 호출하는 부분에서 처리할 수 있도록 에러를 그대로 반환합니다. 
(제가 throw error에 대해서 잘못 이해하고 있었습니다.) 

https://github.com/Team-Seollem/seollem-fe/blob/fb02548dd481b461e02112353a3109946424ebd0/src/apis/httpClientAuth.ts#L15-L24