### PR TITLE
Feature/#71 random memo

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -10,6 +10,7 @@ import {
   LibraryBook,
   RecommendedBooksPage,
   MemoForm,
+  Stats,
 } from '@pages';
 import { PrivateRoute, PublicRoute } from '@components/layout';
 import MemoBooks from '@pages/MemoBooks';
@@ -126,6 +127,14 @@ const Router = createBrowserRouter([
     element: (
       <PrivateRoute>
         <MemoBookDetail />
+      </PrivateRoute>
+    ),
+  },
+  {
+    path: PAGE_URL.MYSTAT,
+    element: (
+      <PrivateRoute>
+        <Stats />
       </PrivateRoute>
     ),
   },

--- a/src/components/Library/BookSlider.tsx
+++ b/src/components/Library/BookSlider.tsx
@@ -9,6 +9,7 @@ import { BookCoverItem } from '@components/common';
 import { PAGE_URL } from '@constants';
 import { BOOKSTATUS } from 'constants/library';
 import useIntersectionObserver from '@hooks/useIntersectionObserver';
+import Title from '@components/common/Title';
 import SkeletonLibraryBooks from './SkeletonLibraryBooks';
 import useBookSlider from './hooks/useBookSlider';
 
@@ -52,14 +53,6 @@ export default function BookSlider({ bookStatus: status }: Props) {
     </>
   );
 }
-
-const Title = styled.h1`
-  color: ${({ theme }) => theme.color.gray01};
-  font-size: ${({ theme }) => theme.fontSize.base};
-  font-weight: bold;
-  margin-bottom: 0.3rem;
-`;
-
 const Container = styled.div`
   width: 100%;
   z-index: 0;

--- a/src/components/MemoBookDetail/MemoBookPage.tsx
+++ b/src/components/MemoBookDetail/MemoBookPage.tsx
@@ -5,12 +5,14 @@ import { toPng } from 'html-to-image';
 import styled from 'styled-components';
 import { FiDownload } from 'react-icons/fi';
 
-import type { MemoBookDetail } from '@projects/types/library';
+import type { MemoBasic, MemoBookDetail } from '@projects/types/library';
 import { getLatestUpdateDate } from '@utils';
 import { BgType, MEMO_BACKGROUND } from 'constants/memoBackground';
 
+type MemoBookType = MemoBasic | MemoBookDetail;
+
 type Props = {
-  memo: MemoBookDetail;
+  memo: MemoBookType;
   memoBookBg: BgType;
 };
 

--- a/src/components/MemoBookDetail/MemoBookPage.tsx
+++ b/src/components/MemoBookDetail/MemoBookPage.tsx
@@ -39,7 +39,7 @@ export default function MemoBookPage({ memo, memoBookBg }: Props) {
         ref={imgRef}
       >
         <MemoInfo>
-          <p>{memo.memoBookPage}</p>
+          <p>{`p. ${memo.memoBookPage}`}</p>
           <p>{date}</p>
         </MemoInfo>
         <MemoContent>
@@ -63,7 +63,8 @@ const Wrapper = styled.div<{ fontColor: string; imageUrl: string }>`
   display: flex;
   flex-direction: column;
   padding: 2rem;
-  height: 30rem;
+  width: 100%;
+  min-height: 25rem;
   z-index: 0;
   background-image: url(${({ imageUrl }) => imageUrl});
   background-size: cover;
@@ -80,6 +81,7 @@ const MemoInfo = styled.div`
 
 const MemoContent = styled.div`
   font-size: ${({ theme }) => theme.fontSize.base};
+  line-height: 150%;
 `;
 
 const DownloadIcon = styled(FiDownload)`

--- a/src/components/MemoBookDetail/MemoBookPage.tsx
+++ b/src/components/MemoBookDetail/MemoBookPage.tsx
@@ -5,14 +5,12 @@ import { toPng } from 'html-to-image';
 import styled from 'styled-components';
 import { FiDownload } from 'react-icons/fi';
 
-import type { MemoBasic, MemoBookDetail } from '@projects/types/library';
+import type { MemoBookDetail } from '@projects/types/library';
 import { getLatestUpdateDate } from '@utils';
 import { BgType, MEMO_BACKGROUND } from 'constants/memoBackground';
 
-type MemoBookType = MemoBasic | MemoBookDetail;
-
 type Props = {
-  memo: MemoBookType;
+  memo: MemoBookDetail;
   memoBookBg: BgType;
 };
 

--- a/src/components/Stats/RandomMemo.tsx
+++ b/src/components/Stats/RandomMemo.tsx
@@ -1,13 +1,53 @@
-import MemoBookPage from '@components/MemoBookDetail/MemoBookPage';
+/* eslint-disable react/no-danger */
+import styled from 'styled-components';
 import Title from '@components/common/Title';
+import { getLatestUpdateDate } from '@utils';
+import { MEMO_TYPES } from '@constants';
+import DOMPurify from 'dompurify';
 import useRandomMemo from './hooks/useRandomMemo';
 
 export default function RandomMemo() {
   const randomMemo = useRandomMemo();
+  const date = getLatestUpdateDate(randomMemo.createdAt, randomMemo.updatedAt);
+
   return (
     <>
       <Title>랜덤 메모</Title>
-      <MemoBookPage memo={randomMemo} memoBookBg="WHITE" />
+      <Wrapper>
+        <Content>
+          <div
+            dangerouslySetInnerHTML={{
+              __html: DOMPurify.sanitize(randomMemo.memoContent),
+            }}
+          />
+        </Content>
+        <Info>{date}</Info>
+        <Info>{MEMO_TYPES[randomMemo.memoType].typeText}</Info>
+        <Info>{`p. ${randomMemo.memoBookPage}`}</Info>
+      </Wrapper>
     </>
   );
 }
+
+const Wrapper = styled.div`
+  width: 100%;
+  margin: 0 auto;
+  padding: 2rem;
+  border-radius: 0.3rem;
+  background-color: ${({ theme }) => theme.color.skyblue01};
+  color: ${({ theme }) => theme.color.gray01};
+  font-size: ${({ theme }) => theme.fontSize.base};
+`;
+
+const Content = styled.div`
+  line-height: 150%;
+  margin-bottom: 1rem;
+  min-height: 5rem;
+  font-family: 'RIDIBatang';
+`;
+
+const Info = styled.div`
+  font-size: ${({ theme }) => theme.fontSize.sm};
+  text-align: right;
+  margin-bottom: 0.3rem;
+`;

--- a/src/components/Stats/RandomMemo.tsx
+++ b/src/components/Stats/RandomMemo.tsx
@@ -1,5 +1,5 @@
 import MemoBookPage from '@components/MemoBookDetail/MemoBookPage';
-import styled from 'styled-components';
+import Title from '@components/common/Title';
 import useRandomMemo from './hooks/useRandomMemo';
 
 export default function RandomMemo() {
@@ -11,8 +11,3 @@ export default function RandomMemo() {
     </>
   );
 }
-
-const Title = styled.h2`
-  font-size: ${({ theme }) => theme.fontSize.md};
-  margin-bottom: 1rem;
-`;

--- a/src/components/Stats/RandomMemo.tsx
+++ b/src/components/Stats/RandomMemo.tsx
@@ -1,0 +1,18 @@
+import MemoBookPage from '@components/MemoBookDetail/MemoBookPage';
+import styled from 'styled-components';
+import useRandomMemo from './hooks/useRandomMemo';
+
+export default function RandomMemo() {
+  const randomMemo = useRandomMemo();
+  return (
+    <>
+      <Title>랜덤 메모</Title>
+      <MemoBookPage memo={randomMemo} memoBookBg="WHITE" />
+    </>
+  );
+}
+
+const Title = styled.h2`
+  font-size: ${({ theme }) => theme.fontSize.md};
+  margin-bottom: 1rem;
+`;

--- a/src/components/Stats/hooks/useRandomMemo.ts
+++ b/src/components/Stats/hooks/useRandomMemo.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query';
+import type { MemoBasic } from '@projects/types/library';
+import { memoService } from '@apis/index';
+import { CACHE_KEYS } from '@constants';
+
+export default function useRandomMemo() {
+  const fallback: MemoBasic = {
+    memoId: 1,
+    memoType: 'BOOK_CONTENT',
+    memoContent: '',
+    memoBookPage: 0,
+    createdAt: '',
+    updatedAt: '',
+  };
+  const { data = fallback } = useQuery({
+    queryKey: CACHE_KEYS.randomMemo,
+    queryFn: memoService.getRandomMemo,
+  });
+  return data;
+}

--- a/src/components/common/Title.tsx
+++ b/src/components/common/Title.tsx
@@ -1,0 +1,16 @@
+import styled from 'styled-components';
+
+type Props = {
+  children: React.ReactNode;
+};
+
+export default function Title({ children }: Props) {
+  return <STitle>{children}</STitle>;
+}
+
+const STitle = styled.h2`
+  color: ${({ theme }) => theme.color.gray01};
+  font-size: ${({ theme }) => theme.fontSize.base};
+  font-weight: bold;
+  margin-bottom: 0.7rem;
+`;

--- a/src/constants/cacheKey.ts
+++ b/src/constants/cacheKey.ts
@@ -11,4 +11,5 @@ export const CACHE_KEYS = {
     bookId,
     memoType,
   ],
+  randomMemo: ['randomMemo'],
 };

--- a/src/pages/Stats.tsx
+++ b/src/pages/Stats.tsx
@@ -1,10 +1,11 @@
 import { PageTitle } from '@components/common';
+import RandomMemo from '@components/Stats/RandomMemo';
 
 export default function Stats() {
   return (
     <>
       <PageTitle title="나의 독서 통계 보기" />
-      <div>stats</div>
+      <RandomMemo />
     </>
   );
 }

--- a/src/pages/Stats.tsx
+++ b/src/pages/Stats.tsx
@@ -1,0 +1,10 @@
+import { PageTitle } from '@components/common';
+
+export default function Stats() {
+  return (
+    <>
+      <PageTitle title="나의 독서 통계 보기" />
+      <div>stats</div>
+    </>
+  );
+}

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -8,3 +8,4 @@ export { default as Library } from './Library';
 export { default as LibraryBook } from './LibraryBook';
 export { default as RecommendedBooksPage } from './RecommendedBooksPage';
 export { default as MemoForm } from './MemoForm';
+export { default as Stats } from './Stats';

--- a/src/types/library.ts
+++ b/src/types/library.ts
@@ -46,13 +46,13 @@ export type MemoBasic = {
   memoType: MemoType;
   memoContent: string;
   memoBookPage: number;
+  createdAt: string;
+  updatedAt: string;
 };
 
 export type MemoBookDetail = MemoBasic & {
   memoAuthority: MemoAuthority;
   memoLikesCount: number;
-  createdAt: string;
-  updatedAt: string;
 };
 
 export type MemoBookDetailResponse = PageableApiResponse<MemoBookDetail>;


### PR DESCRIPTION
## 🔗 ISSUE NUMBER
<!-- closed #[issue-number]로 작성하면 이슈가 닫히고, 링크도 연결할 수 있어요 -->

- closed #71

## 🙌 구현 사항
- useRandomMemo - react-query 훅 
- randomMemo 컴포넌트 

## 📝 구현 설명
### useRandomMemo 
- 서버에서 요청마다 랜덤 메모를 보내주기 때문에 stale time을 따로 설정하지 않았습니다. 

### randomMemo 컴포넌트 
- MemoItem, MemoBookPage 컴포넌트와 중복되는 코드가 많아서 이후에 이슈를 생성해서 공통 컴포넌트를 만들어서 리팩토링할 예정입니다. 
