### PR TITLE
fix: [#72] fix PostBook & BookStatus type

### DIFF
--- a/src/components/PostBook/index.tsx
+++ b/src/components/PostBook/index.tsx
@@ -6,9 +6,13 @@ import {
   Button,
   PageTitle,
 } from '@components/common';
-import { useMutation } from '@tanstack/react-query';
+import { CACHE_KEYS, PAGE_URL } from '@constants';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
+
+import { BookStatus } from '../../types/library';
 import { SearchBookInfo } from '../../types/basic';
 
 type Props = {
@@ -23,7 +27,7 @@ function PostBook({ bookInfoData }: Props) {
   });
 
   const [currentPage, setCurrentPage] = useState<number>(0);
-  const [bookStatus, setBookStatus] = useState<string>('YET');
+  const [bookStatus, setBookStatus] = useState<BookStatus>('YET');
   const [readStartDate, setReadStartDate] = useState<string | null>(null);
   const [readEndDate, setReadEndDate] = useState<string | null>(null);
 
@@ -45,7 +49,8 @@ function PostBook({ bookInfoData }: Props) {
   };
 
   const handleChangeSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    setBookStatus(e.target.value);
+    const { value } = e.target;
+    setBookStatus(value);
     setReadStartDate(null);
     setReadEndDate(null);
   };
@@ -64,12 +69,15 @@ function PostBook({ bookInfoData }: Props) {
   };
 
   const { mutate } = useMutation(bookService.registerBook);
-
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     mutate(postBookInfoData, {
       onSuccess() {
-        toast.success('회원 가입에 성공했습니다.');
+        queryClient.invalidateQueries(CACHE_KEYS.library(bookStatus));
+        toast.success('책 등록에 성공했어요.');
+        navigate(PAGE_URL.LIBRARY);
       },
     });
   };

--- a/src/types/library.ts
+++ b/src/types/library.ts
@@ -5,7 +5,8 @@ type PageableApiResponse<T> = {
   pageInfo: PageInfo;
 };
 
-export type BookStatus = keyof typeof BOOKSTATUS;
+// export type BookStatus = keyof typeof BOOKSTATUS
+export type BookStatus = string;
 
 export type BasicBook = {
   bookId: number;


### PR DESCRIPTION
## 🔗 ISSUE NUMBER
<!-- closed #[issue-number]로 작성하면 이슈가 닫히고, 링크도 연결할 수 있어요 -->

- closed #72  

## 🙌 구현 사항
- 책 등록 후 Library page 로 이동 및 Query Invalidation 적용

## 📝 구현 설명
`queryClient.invalidateQueries(CACHE_KEYS.library(bookStatus))` 적용시 발생한 타입 에러입니다.
`e.target.value` 타입으로 **'YET' | 'ING' | 'DONE'** 적용이 어렵다고 하여 
bookStatus 타입을 string으로 변경했습니다. 변경 후 추가 에러는 발생하고 있지 않지만 더 나은 방안을 고려하겠습니다.
<img width="798" alt="BookStatus type 변경 이유" src="https://user-images.githubusercontent.com/27681985/230015188-85115de0-15fc-47d7-9a6a-7e08f78224c7.png">

```typescript
const [bookStatus, setBookStatus] = useState<BookStatus>('YET');

const handleChangeSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
    const { value} = e.target;  
    setBookStatus(value)
}
```