### PR TITLE
Feature/#80 fix infinite data fetching

### DIFF
--- a/src/components/Library/BookSlider.tsx
+++ b/src/components/Library/BookSlider.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import styled from 'styled-components';
@@ -24,12 +23,7 @@ export default function BookSlider({ bookStatus: status }: Props) {
     bookStatus: status,
   });
 
-  const { ref, isIntersect } = useIntersectionObserver({ threshold: 1.0 });
-  useEffect(() => {
-    if (isIntersect && hasNextPage) {
-      fetchNextPage();
-    }
-  }, [isIntersect, hasNextPage, fetchNextPage]);
+  const { ref, isIntersect } = useIntersectionObserver({ threshold: 0.5 });
 
   if (isLoading) return <SkeletonLibraryBooks />;
 
@@ -37,16 +31,24 @@ export default function BookSlider({ bookStatus: status }: Props) {
     <>
       <Title>{BOOKSTATUS[status].typeText}</Title>
       <Container>
-        <Swiper spaceBetween={5} slidesPerView={4}>
+        <Swiper
+          spaceBetween={5}
+          slidesPerView={4}
+          onReachEnd={() => {
+            if (isIntersect) {
+              fetchNextPage();
+            }
+          }}
+        >
           {books.map((book) => (
             <SwiperSlide key={book.bookId}>
               <BookCoverItem
                 src={book.cover}
                 onClick={() => navigate(`${PAGE_URL.LIBRARY}/${book.bookId}`)}
               />
+              {hasNextPage && !isLoading && <div ref={ref} />}
             </SwiperSlide>
           ))}
-          {hasNextPage && <div ref={ref} />}
         </Swiper>
         <BookShelf />
       </Container>

--- a/src/components/Library/BookSlider.tsx
+++ b/src/components/Library/BookSlider.tsx
@@ -7,7 +7,6 @@ import type { BookStatus } from '@projects/types/library';
 import { BookCoverItem } from '@components/common';
 import { PAGE_URL } from '@constants';
 import { BOOKSTATUS } from 'constants/library';
-import useIntersectionObserver from '@hooks/useIntersectionObserver';
 import Title from '@components/common/Title';
 import SkeletonLibraryBooks from './SkeletonLibraryBooks';
 import useBookSlider from './hooks/useBookSlider';
@@ -23,8 +22,6 @@ export default function BookSlider({ bookStatus: status }: Props) {
     bookStatus: status,
   });
 
-  const { ref, isIntersect } = useIntersectionObserver({ threshold: 0.5 });
-
   if (isLoading) return <SkeletonLibraryBooks />;
 
   return (
@@ -35,7 +32,7 @@ export default function BookSlider({ bookStatus: status }: Props) {
           spaceBetween={5}
           slidesPerView={4}
           onReachEnd={() => {
-            if (isIntersect) {
+            if (hasNextPage) {
               fetchNextPage();
             }
           }}
@@ -46,7 +43,6 @@ export default function BookSlider({ bookStatus: status }: Props) {
                 src={book.cover}
                 onClick={() => navigate(`${PAGE_URL.LIBRARY}/${book.bookId}`)}
               />
-              {hasNextPage && !isLoading && <div ref={ref} />}
             </SwiperSlide>
           ))}
         </Swiper>
@@ -55,6 +51,7 @@ export default function BookSlider({ bookStatus: status }: Props) {
     </>
   );
 }
+
 const Container = styled.div`
   width: 100%;
   z-index: 0;

--- a/src/components/Library/hooks/useBookSlider.ts
+++ b/src/components/Library/hooks/useBookSlider.ts
@@ -19,7 +19,7 @@ export default function useBookSlider({ bookStatus }: Props) {
         const { pageInfo } = lastpage;
         const { totalPages, page: currentPage } = pageInfo;
 
-        return currentPage >= totalPages ? undefined : currentPage + 1;
+        return currentPage < totalPages ? currentPage + 1 : undefined;
       },
       staleTime: 1000 * 60 * 5,
     }

--- a/src/components/MemoBookDetail/MemoBookViewer.tsx
+++ b/src/components/MemoBookDetail/MemoBookViewer.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { Navigation } from 'swiper';
 import { Swiper, SwiperSlide } from 'swiper/react';
@@ -20,17 +19,15 @@ export default function MemoBookViewer() {
   const { memoBookType, handleTypeChange, memoBookBg, handleValueChange } =
     useMemoBookViewer();
 
-  const { memoBooks, hasNextPage, fetchNextPage } = useMemobookDetail({
-    bookId: Number(bookId),
-    memoType: memoBookType,
-  });
+  const { memoBooks, isLoading, hasNextPage, fetchNextPage } =
+    useMemobookDetail({
+      bookId: Number(bookId),
+      memoType: memoBookType,
+    });
 
-  const { ref, isIntersect } = useIntersectionObserver({ threshold: 1.0 });
-  useEffect(() => {
-    if (isIntersect && hasNextPage) {
-      fetchNextPage();
-    }
-  }, [isIntersect, hasNextPage, fetchNextPage]);
+  const { ref, isIntersect } = useIntersectionObserver({
+    threshold: 0.8,
+  });
 
   return (
     <>
@@ -44,13 +41,22 @@ export default function MemoBookViewer() {
         <Text>해당 타입의 메모가 없습니다. 전체 타입으로 조회해 보세요.</Text>
       ) : (
         <Container>
-          <Swiper modules={[Navigation]} slidesPerView={1} navigation>
+          <Swiper
+            modules={[Navigation]}
+            slidesPerView={1}
+            navigation
+            onReachEnd={() => {
+              if (isIntersect) {
+                fetchNextPage();
+              }
+            }}
+          >
             {memoBooks.map((memo) => (
               <SwiperSlide key={memo.memoId}>
                 <MemoBookPage memo={memo} memoBookBg={memoBookBg} />
+                {hasNextPage && !isLoading && <div ref={ref} />}
               </SwiperSlide>
             ))}
-            {hasNextPage && <div ref={ref} />}
           </Swiper>
         </Container>
       )}

--- a/src/components/MemoBookDetail/MemoBookViewer.tsx
+++ b/src/components/MemoBookDetail/MemoBookViewer.tsx
@@ -7,7 +7,6 @@ import 'swiper/css/navigation';
 
 import { MemoTypeSelect } from '@components/MemoForm';
 import { memoBookTypeList } from '@constants';
-import useIntersectionObserver from '@hooks/useIntersectionObserver';
 import useMemobookDetail from './hooks/useMemobookDetail';
 import useMemoBookViewer from './hooks/useMemoBookViewer';
 import MemoBgSelect from './MemoBgSelect';
@@ -24,10 +23,6 @@ export default function MemoBookViewer() {
       bookId: Number(bookId),
       memoType: memoBookType,
     });
-
-  const { ref, isIntersect } = useIntersectionObserver({
-    threshold: 0.8,
-  });
 
   return (
     <>
@@ -46,7 +41,7 @@ export default function MemoBookViewer() {
             slidesPerView={1}
             navigation
             onReachEnd={() => {
-              if (isIntersect) {
+              if (hasNextPage && !isLoading) {
                 fetchNextPage();
               }
             }}
@@ -54,7 +49,6 @@ export default function MemoBookViewer() {
             {memoBooks.map((memo) => (
               <SwiperSlide key={memo.memoId}>
                 <MemoBookPage memo={memo} memoBookBg={memoBookBg} />
-                {hasNextPage && !isLoading && <div ref={ref} />}
               </SwiperSlide>
             ))}
           </Swiper>

--- a/src/components/MemoBookDetail/hooks/useMemobookDetail.ts
+++ b/src/components/MemoBookDetail/hooks/useMemobookDetail.ts
@@ -20,7 +20,7 @@ export default function useMemobookDetail({ bookId, memoType }: Props) {
         const { pageInfo } = lastpage;
         const { totalPages, page: currentPage } = pageInfo;
 
-        return currentPage >= totalPages ? undefined : currentPage + 1;
+        return currentPage < totalPages ? currentPage + 1 : undefined;
       },
       staleTime: 1000 * 60 * 5,
     }


### PR DESCRIPTION
## 🔗 ISSUE NUMBER
<!-- closed #[issue-number]로 작성하면 이슈가 닫히고, 링크도 연결할 수 있어요 -->

- closed #80 

## 🙌 구현 사항
- 슬라이더 무한 스크롤 오류 수정 

## 📝 구현 설명
각 ui 컴포넌트가 처음 렌더링되었을때만 2번재 페이지의 데이터를 가져오고 3번째 페이지의 데이터를 가져오지 못하는 문제가 있었습니다. 이후 다시 컴포넌트가 렌더링 되었을때만 다음 페이지를 가져오고 있어서 이 부분을 수정했습니다. 

이전 코드는 다음 페이지 데이터를 가져오는 로직을 useEffect 내부에서 처리하고 있어서 컴포넌트가 처음 렌더링될 때 한 번만 다음 페이지를 가져오고 있었던 것 같습니다. (현재 페이지 상태가 변경되는 걸 감지되도록 짰어야되는 것 같습니다..!) 

useEffect를 이용하지 않고 Swiper Slider의 onReachEnd 이벤트(`Event will be fired when Swiper reach last slide`)에 fetchNextPage를 연결하는 방식으로 수정했습니다. 이 이벤트를 사용하면 intersectionObserver를 이용하지 않아도 구현이 가능해져서 useIntersecitonObserver 훅을 사용부분도 삭제했습니다. 
https://github.com/Team-Seollem/seollem-fe/blob/ef2bb48297648ca98ed5fd88d35af72bfb0de3eb/src/components/MemoBookDetail/MemoBookViewer.tsx#L38-L55
