### PR TITLE
Feature/#65 stat component

### DIFF
--- a/src/apis/bookService.ts
+++ b/src/apis/bookService.ts
@@ -6,6 +6,7 @@ import type {
   BasicBook,
   EditBook,
   EditResponse,
+  AbandonBookResponse,
 } from '@projects/types/library';
 import type { HttpClientAuthImpl } from './httpClientAuth';
 
@@ -19,6 +20,7 @@ interface BookService {
   registerBook: (bookData: RegisterBook) => Promise<BasicBook>;
   editBookDetail: (bookData: EditBook) => Promise<EditResponse>;
   removeBook: (bookId: number) => Promise<string>;
+  getAbandonBooks: (page: number, size: number) => Promise<AbandonBookResponse>;
 }
 
 export class BookServiceImpl implements BookService {
@@ -64,5 +66,15 @@ export class BookServiceImpl implements BookService {
   removeBook = async (bookId: number) => {
     await this.httpClient.delete<number>(`/books/${bookId}`);
     return '등록하신 책이 삭제되었습니다';
+  };
+
+  getAbandonBooks = async (page: number, size: number) => {
+    const { data } = await this.httpClient.get<AbandonBookResponse>(
+      '/books/abandon',
+      {
+        params: { page, size },
+      }
+    );
+    return data;
   };
 }

--- a/src/apis/bookService.ts
+++ b/src/apis/bookService.ts
@@ -7,9 +7,10 @@ import type {
   EditBook,
   EditResponse,
   AbandonBookResponse,
-  CalendarResponse,
+  ReadEndBookResponse,
 } from '@projects/types/library';
 import type { HttpClientAuthImpl } from './httpClientAuth';
+import { ReadEndBook } from '../types/library';
 
 interface BookService {
   getLibrary: (
@@ -22,12 +23,12 @@ interface BookService {
   editBookDetail: (bookData: EditBook) => Promise<EditResponse>;
   removeBook: (bookId: number) => Promise<string>;
   getAbandonBooks: (page: number, size: number) => Promise<AbandonBookResponse>;
-  getCalendar: (
+  getReadEndBooks: (
     page: number,
     size: number,
     year: number,
     month: number
-  ) => Promise<CalendarResponse>;
+  ) => Promise<ReadEndBook[]>;
 }
 
 export class BookServiceImpl implements BookService {
@@ -85,14 +86,14 @@ export class BookServiceImpl implements BookService {
     return data;
   };
 
-  getCalendar = async (
+  getReadEndBooks = async (
     page: number,
     size: number,
     year: number,
     month: number
   ) => {
-    const { data } = await this.httpClient.get<CalendarResponse>(
-      '/books/calendar',
+    const { data } = await this.httpClient.get<ReadEndBookResponse>(
+      '/books/calender',
       {
         params: {
           page,
@@ -102,6 +103,6 @@ export class BookServiceImpl implements BookService {
         },
       }
     );
-    return data;
+    return data.item;
   };
 }

--- a/src/apis/bookService.ts
+++ b/src/apis/bookService.ts
@@ -7,6 +7,7 @@ import type {
   EditBook,
   EditResponse,
   AbandonBookResponse,
+  CalendarResponse,
 } from '@projects/types/library';
 import type { HttpClientAuthImpl } from './httpClientAuth';
 
@@ -21,6 +22,12 @@ interface BookService {
   editBookDetail: (bookData: EditBook) => Promise<EditResponse>;
   removeBook: (bookId: number) => Promise<string>;
   getAbandonBooks: (page: number, size: number) => Promise<AbandonBookResponse>;
+  getCalendar: (
+    page: number,
+    size: number,
+    year: number,
+    month: number
+  ) => Promise<CalendarResponse>;
 }
 
 export class BookServiceImpl implements BookService {
@@ -73,6 +80,26 @@ export class BookServiceImpl implements BookService {
       '/books/abandon',
       {
         params: { page, size },
+      }
+    );
+    return data;
+  };
+
+  getCalendar = async (
+    page: number,
+    size: number,
+    year: number,
+    month: number
+  ) => {
+    const { data } = await this.httpClient.get<CalendarResponse>(
+      '/books/calendar',
+      {
+        params: {
+          page,
+          size,
+          year,
+          month,
+        },
       }
     );
     return data;

--- a/src/components/Stats/AbandonBooks.tsx
+++ b/src/components/Stats/AbandonBooks.tsx
@@ -1,0 +1,83 @@
+import { BookCoverItem } from '@components/common';
+import Title from '@components/common/Title';
+import { AbandonBook } from '@projects/types/library';
+
+import { Swiper, SwiperSlide } from 'swiper/react';
+import styled from 'styled-components';
+import 'swiper/css';
+import { useNavigate } from 'react-router-dom';
+
+const abandonBooks: AbandonBook[] = [
+  {
+    bookId: 100,
+    createdAt: '2021-01-01',
+    title: '사건',
+    cover: 'http://image.yes24.com/goods/81631163/M',
+  },
+  {
+    bookId: 101,
+    createdAt: '2021-01-01',
+    title: '다른 의견',
+    cover: 'http://image.yes24.com/goods/104498102/M',
+  },
+  {
+    bookId: 102,
+    createdAt: '2021-01-01',
+    title: '어른 이후의 어른',
+    cover: 'https://image.yes24.com/goods/116790019/M',
+  },
+  {
+    bookId: 103,
+    createdAt: '2021-01-01',
+    title: '세피아빛 초상',
+    cover: 'http://image.yes24.com/goods/110164380/M',
+  },
+  {
+    bookId: 104,
+    createdAt: '2021-01-01',
+    title: '이선 프롬',
+    cover: 'http://image.yes24.com/goods/91887643/M',
+  },
+  {
+    bookId: 105,
+    createdAt: '2021-01-01',
+    title: '포스트맨은 벨을 두 번 울린다',
+    cover: 'http://image.yes24.com/momo/TopCate388/MidCate007/6005508.jpg',
+  },
+];
+
+export default function AbandonBooks() {
+  const navigate = useNavigate();
+
+  const handleBookClick = (bookId: number) => {
+    navigate(`/book/library/${bookId}`);
+  };
+
+  return (
+    <div>
+      <Title>잊고 지낸 나의 책</Title>
+      <Container>
+        <Swiper spaceBetween={5} slidesPerView={4}>
+          {abandonBooks.map((book) => (
+            <SwiperSlide
+              key={book.bookId}
+              onClick={() => handleBookClick(book.bookId)}
+            >
+              <BookCoverItem src={book.cover} />
+            </SwiperSlide>
+          ))}
+        </Swiper>
+      </Container>
+    </div>
+  );
+}
+
+const Container = styled.div`
+  width: 100%;
+  z-index: 0;
+  margin-bottom: 1rem;
+  .swiper-wrapper {
+    align-items: baseline;
+    padding: 0 1rem;
+  }
+`;

--- a/src/components/Stats/AbandonBooks.tsx
+++ b/src/components/Stats/AbandonBooks.tsx
@@ -1,50 +1,12 @@
-import { BookCoverItem } from '@components/common';
-import Title from '@components/common/Title';
-import { AbandonBook } from '@projects/types/library';
-
+import { useNavigate } from 'react-router-dom';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import styled from 'styled-components';
 import 'swiper/css';
-import { useNavigate } from 'react-router-dom';
 
-const abandonBooks: AbandonBook[] = [
-  {
-    bookId: 100,
-    createdAt: '2021-01-01',
-    title: '사건',
-    cover: 'http://image.yes24.com/goods/81631163/M',
-  },
-  {
-    bookId: 101,
-    createdAt: '2021-01-01',
-    title: '다른 의견',
-    cover: 'http://image.yes24.com/goods/104498102/M',
-  },
-  {
-    bookId: 102,
-    createdAt: '2021-01-01',
-    title: '어른 이후의 어른',
-    cover: 'https://image.yes24.com/goods/116790019/M',
-  },
-  {
-    bookId: 103,
-    createdAt: '2021-01-01',
-    title: '세피아빛 초상',
-    cover: 'http://image.yes24.com/goods/110164380/M',
-  },
-  {
-    bookId: 104,
-    createdAt: '2021-01-01',
-    title: '이선 프롬',
-    cover: 'http://image.yes24.com/goods/91887643/M',
-  },
-  {
-    bookId: 105,
-    createdAt: '2021-01-01',
-    title: '포스트맨은 벨을 두 번 울린다',
-    cover: 'http://image.yes24.com/momo/TopCate388/MidCate007/6005508.jpg',
-  },
-];
+import Title from '@components/common/Title';
+import { BookCoverItem } from '@components/common';
+
+import useAbandonBooks from './hooks/useAbandonBooks';
 
 export default function AbandonBooks() {
   const navigate = useNavigate();
@@ -53,17 +15,29 @@ export default function AbandonBooks() {
     navigate(`/book/library/${bookId}`);
   };
 
+  const { abandonBooks, hasNextPage, fetchNextPage } = useAbandonBooks();
+
+  if (abandonBooks.length === 0) return null;
+
   return (
     <div>
       <Title>잊고 지낸 나의 책</Title>
       <Container>
-        <Swiper spaceBetween={5} slidesPerView={4}>
+        <Swiper
+          spaceBetween={5}
+          slidesPerView={4}
+          onReachEnd={() => {
+            if (hasNextPage) {
+              fetchNextPage();
+            }
+          }}
+        >
           {abandonBooks.map((book) => (
-            <SwiperSlide
-              key={book.bookId}
-              onClick={() => handleBookClick(book.bookId)}
-            >
-              <BookCoverItem src={book.cover} />
+            <SwiperSlide key={book.bookId}>
+              <BookCoverItem
+                src={book.cover}
+                onClick={() => handleBookClick(book.bookId)}
+              />
             </SwiperSlide>
           ))}
         </Swiper>

--- a/src/components/Stats/Calandar.tsx
+++ b/src/components/Stats/Calandar.tsx
@@ -1,0 +1,20 @@
+import Title from '@components/common/Title';
+import dayjs from 'dayjs';
+import useReadEndBooks from './hooks/useReadEndBooks';
+
+export default function Calandar() {
+  const currentDate = dayjs();
+
+  console.log(currentDate.add(1, 'M').format('YYYY-MM-DD'));
+  console.log(dayjs('2023-04-17T21:25:00').format('MM'));
+
+  const { data } = useReadEndBooks({ year: 2023, month: 4 });
+
+  console.log(data);
+
+  return (
+    <div>
+      <Title>독서 달력</Title>
+    </div>
+  );
+}

--- a/src/components/Stats/Calandar.tsx
+++ b/src/components/Stats/Calandar.tsx
@@ -40,9 +40,19 @@ export default function Calandar() {
           ))}
         </WeekDays>
         <DateGrid>
-          <DateBox date={1} gridColumn={monthYear.firstDayOfWeek + 1} />
+          <DateBox
+            date={1}
+            gridColumn={monthYear.firstDayOfWeek + 1}
+            readEndBooks={readEndbooks[1]}
+          />
           {[...Array(monthYear.lastDate)].map((_, i) =>
-            i > 0 ? <DateBox key={i} date={i + 1} /> : null
+            i > 0 ? (
+              <DateBox
+                key={i}
+                date={i + 1}
+                readEndBooks={readEndbooks[i + 1]}
+              />
+            ) : null
           )}
         </DateGrid>
       </Wrapper>

--- a/src/components/Stats/Calandar.tsx
+++ b/src/components/Stats/Calandar.tsx
@@ -1,20 +1,105 @@
 import Title from '@components/common/Title';
-import dayjs from 'dayjs';
+import { Button } from '@components/common';
+import styled from 'styled-components';
+import { FaChevronLeft, FaChevronRight } from 'react-icons/fa';
+
 import useReadEndBooks from './hooks/useReadEndBooks';
+import DateBox from './DateBox';
+
+const weekDays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
 export default function Calandar() {
-  const currentDate = dayjs();
-
-  console.log(currentDate.add(1, 'M').format('YYYY-MM-DD'));
-  console.log(dayjs('2023-04-17T21:25:00').format('MM'));
-
-  const { data } = useReadEndBooks({ year: 2023, month: 4 });
-
-  console.log(data);
+  const { readEndbooks, updateMonthYear, monthYear } = useReadEndBooks();
 
   return (
     <div>
       <Title>독서 달력</Title>
+      <Wrapper>
+        <Hearder>
+          <ArrowButton
+            styleType="ghost"
+            size="small"
+            onClick={() => updateMonthYear(-1)}
+          >
+            <FaChevronLeft />
+          </ArrowButton>
+          <MonthYear>
+            {monthYear.year} 년 {monthYear.monthName}
+          </MonthYear>
+          <ArrowButton
+            styleType="ghost"
+            size="small"
+            onClick={() => updateMonthYear(1)}
+          >
+            <FaChevronRight />
+          </ArrowButton>
+        </Hearder>
+        <WeekDays>
+          {weekDays.map((day) => (
+            <WeekDay key={day}>{day}</WeekDay>
+          ))}
+        </WeekDays>
+        <DateGrid>
+          <DateBox date={1} gridColumn={monthYear.firstDayOfWeek + 1} />
+          {[...Array(monthYear.lastDate)].map((_, i) =>
+            i > 0 ? <DateBox key={i} date={i + 1} /> : null
+          )}
+        </DateGrid>
+      </Wrapper>
     </div>
   );
 }
+
+const Wrapper = styled.div`
+  width: 100%;
+  margin: 0 auto;
+  margin-bottom: 1rem;
+  padding: 1rem;
+  border: 1px solid ${({ theme }) => theme.color.gray02};
+  border-radius: 0.3rem;
+`;
+
+const Hearder = styled.div`
+  width: 100%;
+  display: grid;
+  grid-gap: 2rem;
+  grid-template-columns: 1fr 4fr 1fr;
+  align-items: center;
+  justify-items: center;
+  text-align: center;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid ${({ theme }) => theme.color.gray02};
+`;
+
+const ArrowButton = styled(Button)`
+  font-size: ${({ theme }) => theme.fontSize.md};
+  color: ${({ theme }) => theme.color.gray01};
+`;
+
+const MonthYear = styled.h2`
+  font-size: ${({ theme }) => theme.fontSize.base};
+  color: ${({ theme }) => theme.color.gray01};
+  font-weight: bold;
+`;
+
+const WeekDays = styled.div`
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  justify-items: center;
+  margin-top: 0.5rem;
+  padding-bottom: 0.3rem;
+  border-bottom: 1px solid ${({ theme }) => theme.color.gray02};
+`;
+
+const WeekDay = styled.div`
+  color: ${({ theme }) => theme.color.gray01};
+  font-size: ${({ theme }) => theme.fontSize.sm};
+`;
+
+const DateGrid = styled.div`
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  justify-items: center;
+`;

--- a/src/components/Stats/CalendarModal.tsx
+++ b/src/components/Stats/CalendarModal.tsx
@@ -1,0 +1,64 @@
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import 'swiper/css';
+import Modal from '@components/common/Modal';
+import useModal from '@hooks/useModal';
+import { ReadEndBook } from '@projects/types/library';
+import { BookCoverItem } from '@components/common';
+
+type Props = {
+  readEndBooks: ReadEndBook[];
+};
+
+export default function CalendarModal({ readEndBooks }: Props) {
+  const navigate = useNavigate();
+  const { isOpen, toggle } = useModal();
+
+  const handleBookClick = (booId: number) => {
+    navigate(`/book/library/${booId}`);
+  };
+
+  return (
+    <>
+      <OpenModalButton src={readEndBooks[0].cover} onClick={toggle} />
+      <Modal isOpen={isOpen} closeModal={toggle}>
+        <h1>다 읽은 책 보러가기</h1>
+        <Container>
+          <Swiper spaceBetween={1} slidesPerView={3}>
+            {readEndBooks.map((book) => (
+              <SwiperSlide key={book.bookId}>
+                <BookCoverItem
+                  src={book.cover}
+                  width="3rem"
+                  onClick={() => handleBookClick(book.bookId)}
+                />
+              </SwiperSlide>
+            ))}
+          </Swiper>
+        </Container>
+      </Modal>
+    </>
+  );
+}
+const OpenModalButton = styled.img`
+  width: 80%;
+  height: auto;
+  max-height: 100%;
+  object-fit: cover;
+  cursor: pointer;
+  transition: transfrom 300ms ease-in;
+  &:hover {
+    transform: scale(1.02);
+  }
+`;
+
+const Container = styled.div`
+  width: 100%;
+  z-index: 0;
+  .swiper-wrapper {
+    align-items: baseline;
+    justify-content: center;
+    margin: 1rem;
+  }
+`;

--- a/src/components/Stats/DateBox.tsx
+++ b/src/components/Stats/DateBox.tsx
@@ -1,5 +1,6 @@
 import { ReadEndBook } from '@projects/types/library';
 import styled from 'styled-components';
+import CalendarModal from './CalendarModal';
 
 type Props = {
   date: number;
@@ -12,9 +13,7 @@ export default function DateBox({ date, gridColumn, readEndBooks }: Props) {
     <Wrapper gridCloumnStart={gridColumn ?? null}>
       <Stack>
         <Date>{date}</Date>
-        {readEndBooks?.map((book) => (
-          <BookCover key={book.bookId} src={book.cover} alt="book-cover-img" />
-        ))}
+        {readEndBooks && <CalendarModal readEndBooks={readEndBooks} />}
       </Stack>
     </Wrapper>
   );
@@ -22,27 +21,22 @@ export default function DateBox({ date, gridColumn, readEndBooks }: Props) {
 
 const Wrapper = styled.div<{ gridCloumnStart: number | null }>`
   width: 100%;
-  height: 100%;
-  min-height: 5rem;
+  height: auto;
+  min-height: 7rem;
+  @media (max-width: 450px) {
+    min-height: 4.8rem;
+  }
   grid-column-start: ${({ gridCloumnStart }) => gridCloumnStart};
 `;
 
 const Stack = styled.div`
   display: flex;
   flex-direction: column;
+  gap: 0.2rem;
 `;
 
 const Date = styled.p`
   font-size: ${({ theme }) => theme.fontSize.sm};
   margin-top: 0.5rem;
-  margin-left: 0.5rem;
-`;
-
-const BookCover = styled.img`
-  width: 100%;
-  height: auto;
-  max-height: 100%;
-  object-fit: cover;
-
-  overflow: hidden;
+  /* margin-left: 0.5rem; */
 `;

--- a/src/components/Stats/DateBox.tsx
+++ b/src/components/Stats/DateBox.tsx
@@ -1,4 +1,3 @@
-import { BookCoverItem } from '@components/common';
 import { ReadEndBook } from '@projects/types/library';
 import styled from 'styled-components';
 
@@ -10,21 +9,22 @@ type Props = {
 
 export default function DateBox({ date, gridColumn, readEndBooks }: Props) {
   return (
-    <Wrapper gridCloumn={gridColumn ?? null}>
+    <Wrapper gridCloumnStart={gridColumn ?? null}>
       <Stack>
         <Date>{date}</Date>
         {readEndBooks?.map((book) => (
-          <BookCoverItem key={book.bookId} width="100%" src={book.cover} />
+          <BookCover key={book.bookId} src={book.cover} alt="book-cover-img" />
         ))}
       </Stack>
     </Wrapper>
   );
 }
 
-const Wrapper = styled.div<{ gridCloumn: number | null }>`
+const Wrapper = styled.div<{ gridCloumnStart: number | null }>`
   width: 100%;
-  height: 5rem;
-  grid-column-start: ${({ gridCloumn }) => gridCloumn};
+  height: 100%;
+  min-height: 5rem;
+  grid-column-start: ${({ gridCloumnStart }) => gridCloumnStart};
 `;
 
 const Stack = styled.div`
@@ -36,4 +36,13 @@ const Date = styled.p`
   font-size: ${({ theme }) => theme.fontSize.sm};
   margin-top: 0.5rem;
   margin-left: 0.5rem;
+`;
+
+const BookCover = styled.img`
+  width: 100%;
+  height: auto;
+  max-height: 100%;
+  object-fit: cover;
+
+  overflow: hidden;
 `;

--- a/src/components/Stats/DateBox.tsx
+++ b/src/components/Stats/DateBox.tsx
@@ -1,0 +1,39 @@
+import { BookCoverItem } from '@components/common';
+import { ReadEndBook } from '@projects/types/library';
+import styled from 'styled-components';
+
+type Props = {
+  date: number;
+  gridColumn?: number;
+  readEndBooks?: ReadEndBook[];
+};
+
+export default function DateBox({ date, gridColumn, readEndBooks }: Props) {
+  return (
+    <Wrapper gridCloumn={gridColumn ?? null}>
+      <Stack>
+        <Date>{date}</Date>
+        {readEndBooks?.map((book) => (
+          <BookCoverItem key={book.bookId} width="100%" src={book.cover} />
+        ))}
+      </Stack>
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div<{ gridCloumn: number | null }>`
+  width: 100%;
+  height: 5rem;
+  grid-column-start: ${({ gridCloumn }) => gridCloumn};
+`;
+
+const Stack = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const Date = styled.p`
+  font-size: ${({ theme }) => theme.fontSize.sm};
+  margin-top: 0.5rem;
+  margin-left: 0.5rem;
+`;

--- a/src/components/Stats/RandomMemo.tsx
+++ b/src/components/Stats/RandomMemo.tsx
@@ -32,6 +32,7 @@ export default function RandomMemo() {
 const Wrapper = styled.div`
   width: 100%;
   margin: 0 auto;
+  margin-bottom: 1rem;
   padding: 2rem;
   border-radius: 0.3rem;
   background-color: ${({ theme }) => theme.color.skyblue01};

--- a/src/components/Stats/hooks/useAbandonBooks.ts
+++ b/src/components/Stats/hooks/useAbandonBooks.ts
@@ -1,0 +1,25 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { bookService } from '@apis/index';
+import { CACHE_KEYS } from '@constants';
+import { AbandonBook } from '@projects/types/library';
+
+const fallback: AbandonBook[] = [];
+export default function useAbandonBookss() {
+  const { data, isLoading, hasNextPage, fetchNextPage } = useInfiniteQuery(
+    CACHE_KEYS.abandonBooks,
+    ({ pageParam = 1 }) => bookService.getAbandonBooks(pageParam, 10),
+    {
+      getNextPageParam: (lastpage) => {
+        const { pageInfo } = lastpage;
+        const { totalPages, page: currentPage } = pageInfo;
+
+        return currentPage < totalPages ? currentPage + 1 : undefined;
+      },
+      staleTime: 1000 * 60 * 5,
+    }
+  );
+
+  const abandonBooks = data?.pages.flatMap((page) => page.item) ?? fallback;
+
+  return { abandonBooks, isLoading, hasNextPage, fetchNextPage };
+}

--- a/src/components/Stats/hooks/useAbandonBooks.ts
+++ b/src/components/Stats/hooks/useAbandonBooks.ts
@@ -4,7 +4,7 @@ import { CACHE_KEYS } from '@constants';
 import { AbandonBook } from '@projects/types/library';
 
 const fallback: AbandonBook[] = [];
-export default function useAbandonBookss() {
+export default function useAbandonBooks() {
   const { data, isLoading, hasNextPage, fetchNextPage } = useInfiniteQuery(
     CACHE_KEYS.abandonBooks,
     ({ pageParam = 1 }) => bookService.getAbandonBooks(pageParam, 10),

--- a/src/components/Stats/hooks/useReadEndBooks.ts
+++ b/src/components/Stats/hooks/useReadEndBooks.ts
@@ -39,7 +39,7 @@ export default function useReadEndBooks() {
     queryKey: CACHE_KEYS.readEndBooks(monthYear.year, monthYear.month),
     queryFn: () =>
       bookService.getReadEndBooks(1, 30, monthYear.year, monthYear.month),
-    staleTime: 1000 * 60 * 5,
+    // staleTime: 1000 * 60 * 5,
     select: readEndDateObj,
   });
   return { readEndbooks, monthYear, updateMonthYear };

--- a/src/components/Stats/hooks/useReadEndBooks.ts
+++ b/src/components/Stats/hooks/useReadEndBooks.ts
@@ -1,0 +1,38 @@
+import { useCallback } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import dayjs from 'dayjs';
+
+import { bookService } from '@apis/index';
+import { CACHE_KEYS } from '@constants';
+import { ReadEndBook, ReadEndBookDateMap } from '@projects/types/library';
+
+type Props = {
+  year: number;
+  month: number;
+};
+
+const fallback: ReadEndBookDateMap = {};
+
+export default function useReadEndBooks({ year, month }: Props) {
+  const readEndDateObj = useCallback(
+    (data: ReadEndBook[]): ReadEndBookDateMap => {
+      return data.reduce((acc, book) => {
+        const date = dayjs(book.readEndDate).format('YYYY-MM-DD');
+        if (!acc[date]) {
+          acc[date] = [];
+        }
+        acc[date].push(book);
+        return acc;
+      }, {} as ReadEndBookDateMap);
+    },
+    []
+  );
+
+  const { data = fallback } = useQuery({
+    queryKey: CACHE_KEYS.readEndBooks(year, month),
+    queryFn: () => bookService.getReadEndBooks(1, 30, year, month),
+    staleTime: 1000 * 60 * 5,
+    select: readEndDateObj,
+  });
+  return { data };
+}

--- a/src/constants/cacheKey.ts
+++ b/src/constants/cacheKey.ts
@@ -13,4 +13,5 @@ export const CACHE_KEYS = {
   ],
   randomMemo: ['randomMemo'],
   abandonBooks: ['abandonBooks'],
+  readEndBooks: (year: number, month: number) => ['readEndBooks', year, month],
 };

--- a/src/constants/cacheKey.ts
+++ b/src/constants/cacheKey.ts
@@ -12,4 +12,5 @@ export const CACHE_KEYS = {
     memoType,
   ],
   randomMemo: ['randomMemo'],
+  abandonBooks: ['abandonBooks'],
 };

--- a/src/pages/Stats.tsx
+++ b/src/pages/Stats.tsx
@@ -1,4 +1,6 @@
 import { PageTitle } from '@components/common';
+import AbandonBooks from '@components/Stats/AbandonBooks';
+
 import RandomMemo from '@components/Stats/RandomMemo';
 
 export default function Stats() {
@@ -6,6 +8,7 @@ export default function Stats() {
     <>
       <PageTitle title="나의 독서 통계 보기" />
       <RandomMemo />
+      <AbandonBooks />
     </>
   );
 }

--- a/src/pages/Stats.tsx
+++ b/src/pages/Stats.tsx
@@ -1,7 +1,7 @@
 import { PageTitle } from '@components/common';
-import AbandonBooks from '@components/Stats/AbandonBooks';
-
 import RandomMemo from '@components/Stats/RandomMemo';
+import AbandonBooks from '@components/Stats/AbandonBooks';
+import Calandar from '@components/Stats/Calandar';
 
 export default function Stats() {
   return (
@@ -9,6 +9,7 @@ export default function Stats() {
       <PageTitle title="나의 독서 통계 보기" />
       <RandomMemo />
       <AbandonBooks />
+      <Calandar />
     </>
   );
 }

--- a/src/pages/Stats.tsx
+++ b/src/pages/Stats.tsx
@@ -7,9 +7,9 @@ export default function Stats() {
   return (
     <>
       <PageTitle title="나의 독서 통계 보기" />
+      <Calandar />
       <RandomMemo />
       <AbandonBooks />
-      <Calandar />
     </>
   );
 }

--- a/src/types/library.ts
+++ b/src/types/library.ts
@@ -125,4 +125,4 @@ export type ReadEndBook = {
 
 export type ReadEndBookResponse = PageableApiResponse<ReadEndBook>;
 
-export type ReadEndBookDateMap = Record<string, ReadEndBook[]>;
+export type ReadEndBookDateMap = Record<number, ReadEndBook[]>;

--- a/src/types/library.ts
+++ b/src/types/library.ts
@@ -117,10 +117,12 @@ export type AbandonBook = {
 
 export type AbandonBookResponse = PageableApiResponse<AbandonBook>;
 
-export type CalendarBook = {
+export type ReadEndBook = {
   bookId: number;
   readEndDate: string;
   cover: string;
 };
 
-export type CalendarResponse = PageableApiResponse<CalendarBook>;
+export type ReadEndBookResponse = PageableApiResponse<ReadEndBook>;
+
+export type ReadEndBookDateMap = Record<string, ReadEndBook[]>;

--- a/src/types/library.ts
+++ b/src/types/library.ts
@@ -107,3 +107,12 @@ export type EditBook = {
 };
 
 export type EditResponse = Omit<EditBook, 'bookId'>;
+
+type AbandonBook = {
+  bookId: number;
+  createdAt: string;
+  title: string;
+  cover: string;
+};
+
+export type AbandonBookResponse = PageableApiResponse<AbandonBook>;

--- a/src/types/library.ts
+++ b/src/types/library.ts
@@ -116,3 +116,11 @@ export type AbandonBook = {
 };
 
 export type AbandonBookResponse = PageableApiResponse<AbandonBook>;
+
+export type CalendarBook = {
+  bookId: number;
+  readEndDate: string;
+  cover: string;
+};
+
+export type CalendarResponse = PageableApiResponse<CalendarBook>;

--- a/src/types/library.ts
+++ b/src/types/library.ts
@@ -108,7 +108,7 @@ export type EditBook = {
 
 export type EditResponse = Omit<EditBook, 'bookId'>;
 
-type AbandonBook = {
+export type AbandonBook = {
   bookId: number;
   createdAt: string;
   title: string;

--- a/src/utils/monthYear.ts
+++ b/src/utils/monthYear.ts
@@ -1,0 +1,35 @@
+import dayjs from 'dayjs';
+
+export type MonthYear = {
+  startDate: dayjs.Dayjs;
+  firstDayOfWeek: number; // startDate의 요일 0 === Sunday
+  lastDate: number;
+  monthName: string;
+  month: number;
+  year: number;
+};
+
+export const getUpdatedMonthYear = (
+  monthYear: MonthYear,
+  monthIncrement: number
+): dayjs.Dayjs => {
+  return monthYear.startDate.clone().add(monthIncrement, 'months');
+};
+
+export const getMonthYearDetails = (initialDate: dayjs.Dayjs): MonthYear => {
+  const month = Number(initialDate.format('M'));
+  const year = Number(initialDate.format('YYYY'));
+  const startDate = dayjs(initialDate).startOf('month');
+  const firstDayOfWeek = Number(startDate.format('d'));
+  const lastDate = Number(startDate.clone().endOf('month').format('D'));
+  const monthName = startDate.format('MMMM');
+  return { startDate, firstDayOfWeek, lastDate, monthName, month, year };
+};
+
+export const getNewMonthYear = (
+  prevData: MonthYear,
+  monthIncrement: number
+): MonthYear => {
+  const newMonthYear = getUpdatedMonthYear(prevData, monthIncrement);
+  return getMonthYearDetails(newMonthYear);
+};


### PR DESCRIPTION
## 🔗 ISSUE NUMBER
<!-- closed #[issue-number]로 작성하면 이슈가 닫히고, 링크도 연결할 수 있어요 -->

- closed #65

## 🙌 구현 사항
- 오래된 책 조회 컴포넌트 기능 
- 달력 컴포넌트(다 읽은 책 조회) 구현 

## 📝 구현 설명
### ✅ 오래된 책 조회

오래된 책 조회에 대한 응답이 빈 배열로 올 경우에는 컴포넌트가 리턴되지 않도록 했습니다. slide 형식의 ui로 구현했고 책 커버 이미지를 클릭하면 책의 상세 페이지로 이동하도록 했습니다. 
https://github.com/Team-Seollem/seollem-fe/blob/e98301b138bc5e1e268d1168acbc1384a605244d/src/components/Stats/AbandonBooks.tsx#L18-L47

### ✅ 달력 컴포넌트 구현 
<img src='https://user-images.githubusercontent.com/96093996/232972162-3503aaee-9d49-4e0f-8e4d-c352625c072c.gif' width='70%'/> 
history repo의 구현에서는 해당 날짜에 일치하는 한 권의 책만을 볼 수 있었는데, 이부분을 개선했습니다. 이제는 해당 연도/월에 해당하는 데이터를 받아와서, 각 날짜(date)를 키로 하고 해당 날짜에 해당하는 데이터들을 배열로 매핑하여 저장합니다.

https://github.com/Team-Seollem/seollem-fe/blob/e98301b138bc5e1e268d1168acbc1384a605244d/src/components/Stats/hooks/useReadEndBooks.ts#L24-L46

날짜에 해당하는 데이터가 있는 경우에는 배열의 첫번째 책의 이미지를 보여주고 이미지를 클릭하면 모달 창을 열어서 해당 날짜에 다 읽은 책을 모아서 조회할 수 있습니다. 모달 창 내부의 책 이미지를 클릭하면 책의 상세페이지로 이동하도록 구현했습니다. 
https://github.com/Team-Seollem/seollem-fe/blob/e98301b138bc5e1e268d1168acbc1384a605244d/src/components/Stats/CalendarModal.tsx#L14-L43