### PR TITLE
✨ feat: [#89] 로그아웃에 queryclient.clear() 추가

### DIFF
--- a/src/components/layout/PrivateHeader.tsx
+++ b/src/components/layout/PrivateHeader.tsx
@@ -6,12 +6,14 @@ import { PAGE_URL } from '@constants';
 import { authService } from '@apis';
 import { loginState } from '@state/atom';
 import { Dropdown } from '@components/common';
+import { useQueryClient } from '@tanstack/react-query';
 import * as S from './styles';
 import Logo from './Logo';
 
 export default function PrivateHeader() {
   const setIsLoggedIn = useSetRecoilState(loginState);
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   const handleMyPage = () => {
     navigate(PAGE_URL.MYPAGE);
@@ -19,6 +21,7 @@ export default function PrivateHeader() {
 
   const handleLogout = () => {
     authService.signOut();
+    queryClient.clear();
     setIsLoggedIn(false);
     navigate(PAGE_URL.ROOT);
   };


### PR DESCRIPTION
## 🔗 ISSUE NUMBER
<!-- closed #[issue-number]로 작성하면 이슈가 닫히고, 링크도 연결할 수 있어요 -->

- closed #89

## 🙌 구현 사항
- 로그아웃 할때 저장된 쿼리 캐시가 삭제되지 않아서 이부분을 수정했습니다.

## 📝 구현 설명
- queryClient.clear()를 사용해서 쿼리 클라이언트의 데이터와 캐시를 삭제하는 로직을 추가했습니다.
https://github.com/Team-Seollem/seollem-fe/blob/8750138d1051d843ef0be821812633576293e806/src/components/layout/PrivateHeader.tsx#L22-L27

