### PR TITLE
Feature/#106 recommend update

### DIFF
--- a/src/components/MemoForm/MemoEditForm.tsx
+++ b/src/components/MemoForm/MemoEditForm.tsx
@@ -24,8 +24,6 @@ export default function MemoEditForm() {
     memoType: 'BOOK_CONTENT',
     memoContent: '',
   };
-
-
   const { editMemo } = useEditMemo();
 
   const { memo, handlePageChange, handleTypeChange, handleContentChange } =

--- a/src/components/RecommendedBooks/RecommendedResult.tsx
+++ b/src/components/RecommendedBooks/RecommendedResult.tsx
@@ -1,14 +1,14 @@
 import { useNavigate } from 'react-router-dom';
 import { BookCoverItem, BookInfoItem, Boxcontainer } from '@components/common';
-import { RecommendedBooksQuery } from '@hooks/query';
 import type { RecommendSort, SearchBookInfo } from '@projects/types/basic';
+import { useRecommendBooks } from './hook/useRecommendBooks';
 
 type Props = {
   sort: RecommendSort;
 };
 
 function RecommendedResult({ sort }: Props) {
-  const { data, isSuccess } = RecommendedBooksQuery(sort);
+  const { data, isSuccess } = useRecommendBooks(sort);
   const navigate = useNavigate();
   return (
     <div>

--- a/src/components/RecommendedBooks/RecommendedSort.tsx
+++ b/src/components/RecommendedBooks/RecommendedSort.tsx
@@ -3,20 +3,24 @@ import { RecommendSort } from '@projects/types/basic';
 import styled from 'styled-components';
 
 type Props = {
+  selectedSort: RecommendSort;
   onChangeList: (value: RecommendSort) => void;
 };
 
-function RecommendedSort({ onChangeList }: Props) {
-  const sortDataList = RECOMMENDED_SORT.map((data) => {
-    return (
-      <li key={data.id}>
-        <button type="button" onClick={() => onChangeList(data.value)}>
+function RecommendedSort({ selectedSort, onChangeList }: Props) {
+  return (
+    <SSortList>
+      {RECOMMENDED_SORT.map((data) => (
+        <STag
+          key={data.id}
+          isSelected={selectedSort === data.value}
+          onClick={() => onChangeList(data.value)}
+        >
           {data.name}
-        </button>
-      </li>
-    );
-  });
-  return <SSortList>{sortDataList}</SSortList>;
+        </STag>
+      ))}
+    </SSortList>
+  );
 }
 
 export default RecommendedSort;
@@ -27,20 +31,18 @@ const SSortList = styled.ul`
   gap: 1rem;
   margin-bottom: 1rem;
   border-bottom: solid 3px ${({ theme }) => theme.color.gray04};
+`;
+const STag = styled.li<{ isSelected: boolean }>`
+  background-color: transparent;
+  font-family: 'Pretendard-Regular';
+  cursor: pointer;
+  padding: 1rem;
+  color: ${({ theme, isSelected }) =>
+    isSelected ? theme.color.gray01 : theme.color.gray02};
+  border-bottom: ${({ theme, isSelected }) =>
+    isSelected ? `solid 1px ${theme.color.gray01}` : 'none'};
 
-  li:hover {
-    border-bottom: solid 1px ${({ theme }) => theme.color.gray01};
-  }
-
-  button {
-    background-color: transparent;
-    font-family: 'Pretendard-Regular';
-    cursor: pointer;
-    padding: 1rem;
-    color: ${({ theme }) => theme.color.gray02};
-    border: none;
-    &:hover {
-      color: ${({ theme }) => theme.color.gray01};
-    }
+  &:hover {
+    color: ${({ theme }) => theme.color.gray01};
   }
 `;

--- a/src/components/RecommendedBooks/hook/useRecommendBooks.ts
+++ b/src/components/RecommendedBooks/hook/useRecommendBooks.ts
@@ -1,0 +1,10 @@
+import { externalService } from '@apis/index';
+import { CACHE_KEYS } from '@constants';
+import type { RecommendSort } from '@projects/types/basic';
+import { useQuery } from '@tanstack/react-query';
+
+export const useRecommendBooks = (sort: RecommendSort) => {
+  return useQuery(CACHE_KEYS.recommendBooks(sort), () =>
+    externalService.getRecommendedBooksList(sort)
+  );
+};

--- a/src/components/RecommendedBooks/hook/useRecommendBooks.ts
+++ b/src/components/RecommendedBooks/hook/useRecommendBooks.ts
@@ -1,10 +1,28 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { CACHE_KEYS, RECOMMENDED_SORT } from '@constants';
+import type { RecommendSort, SearchBookInfo } from '@projects/types/basic';
 import { externalService } from '@apis/index';
-import { CACHE_KEYS } from '@constants';
-import type { RecommendSort } from '@projects/types/basic';
-import { useQuery } from '@tanstack/react-query';
 
 export const useRecommendBooks = (sort: RecommendSort) => {
-  return useQuery(CACHE_KEYS.recommendBooks(sort), () =>
-    externalService.getRecommendedBooksList(sort)
-  );
+  const fallback: SearchBookInfo[] = [];
+
+  const { data = fallback, isSuccess } = useQuery({
+    queryKey: CACHE_KEYS.recommendBooks(sort),
+    queryFn: () => externalService.getRecommendedBooksList(sort),
+    staleTime: 1000 * 60 * 60 * 24,
+  });
+  return { data, isSuccess };
+};
+
+export const usePrefetchRecommendBooks = () => {
+  const queryClient = useQueryClient();
+  const recommendedSortValues = RECOMMENDED_SORT.map((sort) => sort.value);
+
+  recommendedSortValues.forEach((sort) => {
+    queryClient.prefetchQuery({
+      queryKey: CACHE_KEYS.recommendBooks(sort),
+      queryFn: () => externalService.getRecommendedBooksList(sort),
+      staleTime: 1000 * 60 * 60 * 24,
+    });
+  });
 };

--- a/src/constants/cacheKey.ts
+++ b/src/constants/cacheKey.ts
@@ -1,3 +1,4 @@
+import { RecommendSort } from '@projects/types/basic';
 import { BookStatus, MemoBookType } from '@projects/types/library';
 
 export const CACHE_KEYS = {
@@ -26,4 +27,5 @@ export const CACHE_KEYS = {
     'memoBook',
     bookId,
   ],
+  recommendBooks: (sort: RecommendSort) => ['recommendBooks', sort],
 };

--- a/src/hooks/query/index.ts
+++ b/src/hooks/query/index.ts
@@ -1,14 +1,8 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { externalService } from '@apis/index';
-import type { RecommendSort } from '@projects/types/basic';
 
 // 추천 책 query
-export const RecommendedBooksQuery = (sort: RecommendSort) => {
-  return useQuery(['RecommendedBooks', sort], () =>
-    externalService.getRecommendedBooksList(sort)
-  );
-};
 
 // 책 검색 결과 query
 export const SearchBookQuery = (searchQuery: string) => {

--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -1,10 +1,13 @@
 import { useNavigate } from 'react-router-dom';
 import { BookAddButton, PageTitle } from '@components/common';
 import BookSlider from '@components/Library/BookSlider';
-import { PAGE_URL } from '../constants/path';
+import { PAGE_URL } from '@constants';
+import { usePrefetchRecommendBooks } from '@components/RecommendedBooks/hook/useRecommendBooks';
 
 export default function Library() {
   const navigate = useNavigate();
+
+  usePrefetchRecommendBooks();
   return (
     <>
       <PageTitle title="나만의 서재" />

--- a/src/pages/RecommendedBooksPage.tsx
+++ b/src/pages/RecommendedBooksPage.tsx
@@ -15,7 +15,7 @@ function RecommendedBooksPage() {
 
   return (
     <>
-      <PageTitle title="추천" />
+      <PageTitle title="추천책" />
       <RecommendedSort selectedSort={sort} onChangeList={onChangeList} />
       <RecommendedResult sort={sort} />
     </>

--- a/src/pages/RecommendedBooksPage.tsx
+++ b/src/pages/RecommendedBooksPage.tsx
@@ -16,7 +16,7 @@ function RecommendedBooksPage() {
   return (
     <>
       <PageTitle title="추천" />
-      <RecommendedSort onChangeList={onChangeList} />
+      <RecommendedSort selectedSort={sort} onChangeList={onChangeList} />
       <RecommendedResult sort={sort} />
     </>
   );


### PR DESCRIPTION
## 🔗 ISSUE NUMBER
<!-- closed #[issue-number]로 작성하면 이슈가 닫히고, 링크도 연결할 수 있어요 -->

- closed #106 

## 🙌 구현 사항
- 추천책 페이지 prefetch 적용
- stale time 적용(알라딘 api 데이터가 바뀌지 않기 때문에)
- (ui)선택된 탭 ui 추가

> Before
<img alt='before' width='400px' src='https://github.com/Team-Seollem/seollem-fe/assets/96093996/cbea3aa5-31be-40da-a9af-f860ebec5678' />


> After
<img alt='after' width='400px' src='https://github.com/Team-Seollem/seollem-fe/assets/96093996/06bd414d-1c46-405d-95d0-8d4e924bde30'/>


## 📝 구현 설명
### ✅ 추천책 페이지 prefetch 적용 + stale time 적용
서버에서 알라딘 api를 이용해 데이터를 보내주기 때문에 우리 서비스의 다른 api보다 응답 속도가 느렸습니다. 또한 알라딘 api 응답 데이터가 수시로 바뀌지 않기 때문에 최신 데이터를 불러올 필요가 없을 것으로 판단돼서 stale time 을 1시간으로 지정했습니다. 
- 해당 훅 파일은 compoent 내의 hook 폴더로 이동시켰습니다. 

https://github.com/Team-Seollem/seollem-fe/blob/dc6cc29828217dbb085b12ee0a29bd27a610e7ea/src/components/RecommendedBooks/hook/useRecommendBooks.ts#L6-L28

- usePrefetchRecommendBooks은 Library 컴포넌트가 렌더링 되면 실행하도록 했습니다. 
https://github.com/Team-Seollem/seollem-fe/blob/dc6cc29828217dbb085b12ee0a29bd27a610e7ea/src/pages/Library.tsx#L7-L11

### ✅ (ui)선택된 탭 ui 추가
기존에는 tab을 hover시에만 ui 변화가 있었는데 선택된 tab에 대한 ui를 추가했습니다. 
https://github.com/Team-Seollem/seollem-fe/blob/dc6cc29828217dbb085b12ee0a29bd27a610e7ea/src/components/RecommendedBooks/RecommendedSort.tsx#L5-L48
