### PR TITLE
Feature/#112 memo delete modal fix

### DIFF
--- a/src/components/LibraryBook/DeleteConfirmButton.tsx
+++ b/src/components/LibraryBook/DeleteConfirmButton.tsx
@@ -5,17 +5,18 @@ import useModal from '@hooks/useModal';
 import Modal from '@components/common/Modal';
 
 type Props = {
+  memoId: number;
   onConfirm: () => void;
 };
 
-export default function DeleteConfirmButton({ onConfirm }: Props) {
+export default function DeleteConfirmButton({ onConfirm, memoId }: Props) {
   const { isOpen, toggle } = useModal();
   return (
     <>
       <OpenConfirmModalButton styleType="ghost" size="small" onClick={toggle}>
         <BsTrashFill />
       </OpenConfirmModalButton>
-      <Modal isOpen={isOpen} closeModal={toggle}>
+      <Modal isOpen={isOpen} closeModal={toggle} modalId={memoId}>
         정말 메모를 삭제하시겠습니까?
         <ButtonGroup>
           <SButton styleType="neutral" size="small" onClick={toggle}>

--- a/src/components/LibraryBook/MemoItem.tsx
+++ b/src/components/LibraryBook/MemoItem.tsx
@@ -38,6 +38,7 @@ export default function MemoItem({
           </Button>
           <DeleteConfirmButton
             onConfirm={() => handleDeleteMemo(memo.memoId)}
+            memoId={memo.memoId}
           />
         </div>
       </InfoContainer>

--- a/src/components/LibraryBook/MemoItem.tsx
+++ b/src/components/LibraryBook/MemoItem.tsx
@@ -1,8 +1,9 @@
 /* eslint-disable react/no-danger */
 import styled from 'styled-components';
 import DOMPurify from 'dompurify';
-
+import { useNavigate } from 'react-router-dom';
 import { FaPen } from 'react-icons/fa';
+
 import { MEMO_TYPES } from '@constants';
 import { getLatestUpdateDate } from '@utils';
 import type { MemoBookDetail } from '@projects/types/library';
@@ -11,19 +12,26 @@ import MemoAuthorityType from '@components/LibraryBook/MemoAuthorityType';
 import DeleteConfirmButton from './DeleteConfirmButton';
 import MemoLikes from './MemoLikes';
 import useMemoLike from './hooks/useMemoLike';
+import useDeleteMemo from './hooks/useDeleteMemo';
 
 type Props = {
   memo: MemoBookDetail;
-  handleEditMemo: (memoId: number) => void;
-  handleDeleteMemo: (memoId: number) => void;
+  bookId: number;
 };
 
-export default function MemoItem({
-  memo,
-  handleEditMemo,
-  handleDeleteMemo,
-}: Props) {
+export default function MemoItem({ memo, bookId }: Props) {
+  const navigate = useNavigate();
   const { likeMyMemo, unlikeMyMemo } = useMemoLike();
+  const deleteMemo = useDeleteMemo();
+
+  const handleEditMemo = (memoId: number) => {
+    navigate(`/book/library/${bookId}/memo/${memoId}`);
+  };
+
+  const handleDeleteMemo = (memoId: number) => {
+    if (!bookId) return;
+    deleteMemo({ bookId: Number(bookId), memoId });
+  };
   return (
     <Wrapper>
       <InfoContainer>

--- a/src/components/LibraryBook/MemoList.tsx
+++ b/src/components/LibraryBook/MemoList.tsx
@@ -5,7 +5,6 @@ import { TbPlus } from 'react-icons/tb';
 import { Button } from '@components/common';
 import useMemobookDetail from '@components/MemoBookDetail/hooks/useMemobookDetail';
 import useIntersectionObserver from '@hooks/useIntersectionObserver';
-import useDeleteMemo from './hooks/useDeleteMemo';
 import MemoItem from './MemoItem';
 
 export default function MemoList() {
@@ -21,20 +20,10 @@ export default function MemoList() {
 
   const { ref, isIntersect } = useIntersectionObserver({ threshold: 0.2 });
 
-  const deleteMemo = useDeleteMemo();
-
   const handleAddMemo = () => {
     navigate(`/book/library/${bookId}/memo`);
   };
 
-  const handleEditMemo = (memoId: number) => {
-    navigate(`/book/library/${bookId}/memo/${memoId}`);
-  };
-
-  const handleDeleteMemo = (memoId: number) => {
-    if (!bookId) return;
-    deleteMemo({ bookId: Number(bookId), memoId });
-  };
   useEffect(() => {
     if (hasNextPage && isIntersect) {
       fetchNextPage();
@@ -61,12 +50,7 @@ export default function MemoList() {
       </BoxTitle>
       <List>
         {memoBooks.map((memo) => (
-          <MemoItem
-            key={memo.memoId}
-            memo={memo}
-            handleEditMemo={handleEditMemo}
-            handleDeleteMemo={handleDeleteMemo}
-          />
+          <MemoItem key={memo.memoId} memo={memo} bookId={Number(bookId)} />
         ))}
         {!isLoading && hasNextPage && <div ref={ref} />}
       </List>

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -6,10 +6,16 @@ interface Props {
   isOpen: boolean;
   closeModal: () => void;
   children: React.ReactNode;
+  modalId?: number;
 }
-export default function Modal({ closeModal, isOpen, children }: Props) {
+export default function Modal({
+  closeModal,
+  isOpen,
+  children,
+  modalId,
+}: Props) {
   return (
-    <ReactPortal wrapperId="modal-root">
+    <ReactPortal wrapperId={`modal-wrapper-${modalId}`}>
       {isOpen && (
         <ModalBackground onClick={closeModal}>
           <ModalContainer


### PR DESCRIPTION
## 🔗 ISSUE NUMBER
<!-- closed #[issue-number]로 작성하면 이슈가 닫히고, 링크도 연결할 수 있어요 -->

- closed #112

## 🙌 구현 사항
메모를 삭제한 이후에 다른 메모에 대한 삭제 모달을 띄울 수 없는 오류가 있어서 이를 수정했습니다.

## 📝 구현 설명
해당 오류는 메모를 삭제하면 메모 아이템이 화면에서 사라지면서 삭제하는 모달을 띄우는 potal 자체가 사라지기 때문으로 파악했습니다. 
메모들이 모두 같은 potalid로 메모를 갖고 있어서 생긴 문제라고 판단해서 modal props에 modal Id를 추가해서 메모id별로 다른 모달 루트  potal을 가지게 해서 문제를 해결했습니다. 

https://github.com/Team-Seollem/seollem-fe/blob/58b53d916a63bd1a2b38b7fbb37a1fca7c71e602/src/components/common/Modal.tsx#L5-L19

https://github.com/Team-Seollem/seollem-fe/blob/58b53d916a63bd1a2b38b7fbb37a1fca7c71e602/src/components/LibraryBook/DeleteConfirmButton.tsx#L7-L20
